### PR TITLE
feat!: use a http lib agnostic version of the exception filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then check [NestJS documentation](https://docs.nestjs.com/exception-filters#bind
 
 ##### As a global filter
 
-In `main.ts` add `app.useGlobalFilters(new HttpExceptionFilter())` as the following
+In `main.ts` add `app.useGlobalFilters(new HttpExceptionFilter(app.getHttpAdapter()))` as the following
 
 ```ts
 import { NestFactory } from '@nestjs/core';
@@ -51,7 +51,7 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule);
 
-  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalFilters(new HttpExceptionFilter(app.getHttpAdapter()));
 
   ...
 }

--- a/examples/express-example-with-default-settings/README.md
+++ b/examples/express-example-with-default-settings/README.md
@@ -16,7 +16,7 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule);
 
-  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalFilters(new HttpExceptionFilter(app.getHttpAdapter()));
 
   ...
 }

--- a/examples/express-example-with-default-settings/src/main.ts
+++ b/examples/express-example-with-default-settings/src/main.ts
@@ -15,7 +15,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.setGlobalPrefix(globalPrefix);
-  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalFilters(new HttpExceptionFilter(app.getHttpAdapter()));
 
   await app.listen(port, () => {
     Logger.log('Listening at http://localhost:' + port + '/' + globalPrefix);

--- a/examples/fastify-example-with-default-settings/README.md
+++ b/examples/fastify-example-with-default-settings/README.md
@@ -19,7 +19,7 @@ async function bootstrap() {
     new FastifyAdapter(),
   );
 
-  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalFilters(new HttpExceptionFilter(app.getHttpAdapter()));
 
   ...
 }

--- a/libs/nest-problem-details-filter/README.md
+++ b/libs/nest-problem-details-filter/README.md
@@ -18,7 +18,7 @@ Then check [NestJS documentation](https://docs.nestjs.com/exception-filters#bind
 
 ##### As a global filter
 
-In `main.ts` add `app.useGlobalFilters(new HttpExceptionFilter())` as the following
+In `main.ts` add `app.useGlobalFilters(new HttpExceptionFilter(app.getHttpAdapter()))` as the following
 
 ```ts
 import { NestFactory } from '@nestjs/core';
@@ -30,16 +30,19 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule);
 
-  app.useGlobalFilters(new HttpExceptionFilter());
+  const httpAdapterHost = app.get(App)
+  app.useGlobalFilters(new HttpExceptionFilter(app.getHttpAdapter()));
 
   ...
 }
 ```
 
+Note that the `app.getHttpAdapter()` argument is needed because the `HttpExceptionFilter` works for any kind of NestJS HTTP adapter!
+
 `HttpExceptionFilter` accepts a base URI for if you want to return absolute URIs for your problem types, e.g:
 
 ```ts
-  app.useGlobalFilters(new HttpExceptionFilter('https://example.org'));
+  app.useGlobalFilters(new HttpExceptionFilter(app.getHttpAdapter(), 'https://example.org'));
 ```
 
 Will return:


### PR DESCRIPTION
closes #7

this introduces a breaking change because we have a new mandatory parameter for `HttpExceptionFilter`

![image](https://github.com/Fcmam5/nest-problem-details/assets/13461315/7bc31e59-9d23-439c-9229-9b48cdf0b01a)
