### PR TITLE
Refactoring, fixing and simplifying interfaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,4 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm test
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance --access public

--- a/libs/nest-problem-details-filter/README.md
+++ b/libs/nest-problem-details-filter/README.md
@@ -30,7 +30,6 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule);
 
-  const httpAdapterHost = app.get(App)
   app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost)));
 
   ...

--- a/libs/nest-problem-details-filter/package.json
+++ b/libs/nest-problem-details-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-problem-details-filter",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A NestJS exception filter to convert JSON responses to RFC-7807-compliant format. This standardizes HTTP responses and sets `Content-Type` to `application/problem+json`",
   "license": "MIT",
   "main": "dist/index.js",

--- a/libs/nest-problem-details-filter/package.json
+++ b/libs/nest-problem-details-filter/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nest-problem-details-filter",
-  "version": "1.1.1",
+  "version": "1.1.2",
+  "description": "A NestJS exception filter to convert JSON responses to RFC-7807-compliant format. This standardizes HTTP responses and sets `Content-Type` to `application/problem+json`",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,6 +17,20 @@
     "url": "https://github.com/Fcmam5/nest-http-problem-details/issues"
   },
   "homepage": "https://github.com/Fcmam5/nest-http-problem-details#readme",
+  "keywords": [
+    "nestjs",
+    "nest",
+    "problem-details",
+    "rfc7807",
+    "http",
+    "api",
+    "rest",
+    "json"
+  ],
+  "funding": {
+    "type": "individual",
+    "url": "https://github.com/sponsors/Fcmam5"
+  },
   "scripts": {
     "build": "nest build",
     "prepack": "rm -rf dist && npm run build",
@@ -52,5 +67,9 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^6.0.3"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0"
   }
 }

--- a/libs/nest-problem-details-filter/src/filters/constants.ts
+++ b/libs/nest-problem-details-filter/src/filters/constants.ts
@@ -38,3 +38,5 @@ export const defaultHttpErrors: IDefaultHTTPErrors = {
 export const BASE_PROBLEMS_URI_KEY = 'BASE_PROBLEMS_URI';
 export const HTTP_ERRORS_MAP_KEY = 'HTTP_ERRORS_MAP';
 export const HTTP_EXCEPTION_FILTER_KEY = 'HTTP_EXCEPTION_FILTER';
+
+export const PROBLEM_CONTENT_TYPE = 'application/problem+json';

--- a/libs/nest-problem-details-filter/src/filters/constants.ts
+++ b/libs/nest-problem-details-filter/src/filters/constants.ts
@@ -25,13 +25,23 @@ export const defaultHttpErrors: IDefaultHTTPErrors = {
   421: 'misdirected',
   422: 'unprocessable-entity',
   424: 'failed-dependency',
+  425: 'too-early',
+  426: 'upgrade-required',
+  428: 'precondition-required',
   429: 'too-many-requests',
+  431: 'request-header-fields-too-large',
+  451: 'unavailable-for-legal-reasons',
   500: 'internal-server-error',
   501: 'not-implemented',
   502: 'bad-gateway',
   503: 'service-unavailable',
   504: 'gateway-timeout',
   505: 'http-version-not-supported',
+  506: 'variant-also-negotiates',
+  507: 'insufficient-storage',
+  508: 'loop-detected',
+  510: 'not-extended',
+  511: 'network-authentication-required',
 };
 
 // Provider keys

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.spec.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.spec.ts
@@ -259,12 +259,9 @@ describe('HttpExceptionFilter', () => {
     });
   });
 
-  describe.each([
-    ['HttpAdapterHost', mockHttpAdatperHost as HttpAdapterHost],
-    ['HttpAdapter', mockHttpAdapter as HttpAdapterHost['httpAdapter']],
-  ])('when used outside a module -- using %s', (_, httpAdapterOrHost) => {
+  describe('when used outside a module', () => {
     beforeAll(() => {
-      filter = new HttpExceptionFilter(httpAdapterOrHost);
+      filter = new HttpExceptionFilter(mockHttpAdatperHost as HttpAdapterHost);
     });
 
     it('should map default exception when thrown with not parameters', () => {

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.spec.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.spec.ts
@@ -5,15 +5,13 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
-import {
-  HttpExceptionFilter,
-  PROBLEM_CONTENT_TYPE,
-} from './http-exception.filter';
+import { HttpExceptionFilter } from './http-exception.filter';
 import { IErrorDetail, IProblemDetail } from './http-exception.interface';
 import {
   HTTP_EXCEPTION_FILTER_KEY,
   HTTP_ERRORS_MAP_KEY,
   BASE_PROBLEMS_URI_KEY,
+  PROBLEM_CONTENT_TYPE,
 } from './constants';
 import { NestProblemDetailsModule } from '../nest-problem-details.module';
 import { HttpAdapterHost } from '@nestjs/core';

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.spec.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.spec.ts
@@ -82,7 +82,7 @@ describe('HttpExceptionFilter', () => {
           title,
           status,
           type: 'forbidden',
-          detail: 'Forbidden', // TODO defaults are not needed
+          detail: 'Forbidden',
         };
 
         filter.catch(new ForbiddenException(title), mockArgumentsHost);
@@ -103,6 +103,40 @@ describe('HttpExceptionFilter', () => {
         };
 
         filter.catch(new ForbiddenException(title, details), mockArgumentsHost);
+
+        assertResponse(status, expectation);
+      });
+
+      it('should fallback to unknown-error for valid but unmapped status codes', () => {
+        const status = 452; // Not a standard HTTP status code
+
+        const expectation: IProblemDetail = {
+          title: 'Custom error',
+          status,
+          type: 'unknown-error',
+        };
+
+        filter.catch(
+          new HttpException(expectation.title, status),
+          mockArgumentsHost,
+        );
+
+        assertResponse(status, expectation);
+      });
+
+      it('should fallback to unsupported-http-code for non-standard HTTP codes', () => {
+        const status = 999;
+
+        const expectation: IProblemDetail = {
+          title: 'Custom error',
+          status,
+          type: 'unsupported-http-code',
+        };
+
+        filter.catch(
+          new HttpException(expectation.title, status),
+          mockArgumentsHost,
+        );
 
         assertResponse(status, expectation);
       });

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.spec.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.spec.ts
@@ -140,6 +140,34 @@ describe('HttpExceptionFilter', () => {
 
         assertResponse(status, expectation);
       });
+
+      it('should map custom fields from error object into response body', () => {
+        const status = HttpStatus.FORBIDDEN;
+        const errorObj = {
+          message: 'You do not have enough credit.',
+          error: {
+            type: 'out-of-credit',
+            detail: 'Your current balance is 30, but that costs 50.',
+            instance: '/account/12345/msgs/abc',
+            balance: 30,
+            accounts: ['/account/12345', '/account/67890'],
+          },
+        };
+
+        const expectation = {
+          type: 'out-of-credit',
+          title: 'You do not have enough credit.',
+          status,
+          detail: 'Your current balance is 30, but that costs 50.',
+          instance: '/account/12345/msgs/abc',
+          balance: 30,
+          accounts: ['/account/12345', '/account/67890'],
+        };
+
+        filter.catch(new HttpException(errorObj, status), mockArgumentsHost);
+
+        assertResponse(status, expectation);
+      });
     });
 
     describe('the generic HttpException', () => {

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
@@ -80,7 +80,10 @@ export class HttpExceptionFilter implements ExceptionFilter {
   }
 
   private getDefaultType(status: number) {
-    return this.defaultHttpErrors[status];
+    if (status < 100 || status > 599) {
+      return 'unsupported-http-code';
+    }
+    return this.defaultHttpErrors[status] ?? 'unknown-error';
   }
 }
 

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
@@ -57,6 +57,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
       } else {
         if (errorResponse.error) {
           type = errorResponse.error.type;
+          detail = errorResponse.error.detail;
           objectExtras = {
             ...errorResponse.error,
           };

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
@@ -46,7 +46,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     let title: string;
     let detail;
     let type: string | undefined;
-    let objectExtras = {};
+    let objectExtras;
 
     if (typeof errorResponse === 'string') {
       title = errorResponse;
@@ -56,11 +56,10 @@ export class HttpExceptionFilter implements ExceptionFilter {
         detail = errorResponse.error;
       } else {
         if (errorResponse.error) {
-          type = errorResponse.error.type;
-          detail = errorResponse.error.detail;
-          objectExtras = {
-            ...errorResponse.error,
-          };
+          const { type: _type, detail: _detail, ...rest } = errorResponse.error;
+          type = _type;
+          detail = _detail;
+          objectExtras = rest;
         }
       }
     }

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
@@ -10,10 +10,9 @@ import {
   BASE_PROBLEMS_URI_KEY,
   defaultHttpErrors as _defaultHttpErrors,
   HTTP_ERRORS_MAP_KEY,
+  PROBLEM_CONTENT_TYPE,
 } from './constants';
 import { IErrorDetail } from './http-exception.interface';
-
-export const PROBLEM_CONTENT_TYPE = 'application/problem+json';
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
@@ -18,9 +18,7 @@ import { IErrorDetail } from './http-exception.interface';
 export class HttpExceptionFilter implements ExceptionFilter {
   constructor(
     @Inject(HttpAdapterHost)
-    private readonly httpAdapterOrHost:
-      | HttpAdapterHost
-      | HttpAdapterHost['httpAdapter'],
+    private readonly httpAdapterHost: HttpAdapterHost,
     @Inject(BASE_PROBLEMS_URI_KEY)
     private baseUri = '',
     @Inject(HTTP_ERRORS_MAP_KEY)
@@ -28,13 +26,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
   ) {}
 
   catch(exception: HttpException, host: ArgumentsHost): void {
-    // Using the HttpAdapterHost allows us to support both
-    // the HttpAdapterHost and the HttpAdapterHost.httpAdapter for an easier API.
-    const httpAdapter =
-      // Using property in operator instead of instanceof for flexibility sake.
-      'httpAdapter' in this.httpAdapterOrHost
-        ? this.httpAdapterOrHost.httpAdapter
-        : this.httpAdapterOrHost;
+    const httpAdapter = this.httpAdapterHost.httpAdapter;
 
     const ctx = host.switchToHttp();
     const response = ctx.getResponse();

--- a/libs/nest-problem-details-filter/src/filters/http-exception.interface.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.interface.ts
@@ -14,5 +14,6 @@ export interface IErrorDetail {
     type?: string;
     instance?: string;
     detail?: string;
+    [key: string]: unknown;
   };
 }

--- a/libs/nest-problem-details-filter/src/index.ts
+++ b/libs/nest-problem-details-filter/src/index.ts
@@ -5,4 +5,10 @@ export {
   BASE_PROBLEMS_URI_KEY,
   HTTP_ERRORS_MAP_KEY,
   HTTP_EXCEPTION_FILTER_KEY,
+  PROBLEM_CONTENT_TYPE,
 } from './filters/constants';
+
+export {
+  IProblemDetail,
+  IErrorDetail,
+} from './filters/http-exception.interface';

--- a/libs/nest-problem-details-filter/tests/http-exception.express.spec.ts
+++ b/libs/nest-problem-details-filter/tests/http-exception.express.spec.ts
@@ -1,5 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { INestApplication } from '@nestjs/common';
+import {
+  ExpressAdapter,
+  NestExpressApplication,
+} from '@nestjs/platform-express';
 import { HttpAdapterHost } from '@nestjs/core';
 import { HttpExceptionFilter } from '../src/filters/http-exception.filter';
 import { TestAppModule, TestAppModuleWithModule } from './test-app.module';
@@ -13,7 +17,10 @@ describe('Express', () => {
   runIntegrationTests(
     'as a global filter',
     async () => {
-      const app = await NestFactory.create(TestAppModule);
+      const app = await NestFactory.create<NestExpressApplication>(
+        TestAppModule,
+        new ExpressAdapter(),
+      );
       app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost)));
       await app.init();
       return app;
@@ -24,7 +31,10 @@ describe('Express', () => {
   runIntegrationTests(
     'as a module',
     async () => {
-      const app = await NestFactory.create(TestAppModuleWithModule);
+      const app = await NestFactory.create<NestExpressApplication>(
+        TestAppModuleWithModule,
+        new ExpressAdapter(),
+      );
       await app.init();
       return app;
     },

--- a/libs/nest-problem-details-filter/tests/http-exception.generic.spec.ts
+++ b/libs/nest-problem-details-filter/tests/http-exception.generic.spec.ts
@@ -1,7 +1,33 @@
+import { NestFactory } from '@nestjs/core';
+import { INestApplication } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { HttpExceptionFilter } from '../src/filters/http-exception.filter';
+import { TestAppModule, TestAppModuleWithModule } from './test-app.module';
 import { runIntegrationTests } from './integration-tests.suite';
 
-describe('Generic HttpAdapter (TBD)', () => {
-  // TODO: Add a generic HTTP adapter test setup here once a custom adapter is defined.
-  // This placeholder ensures the test suite structure is ready for a third adapter.
-  it.todo('should run the shared integration suite against a generic HttpAdapter');
+function getServer(app: INestApplication): any {
+  return app.getHttpServer();
+}
+
+describe('Default (Generic) Adapter', () => {
+  runIntegrationTests(
+    'as a global filter',
+    async () => {
+      const app = await NestFactory.create(TestAppModule);
+      app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost)));
+      await app.init();
+      return app;
+    },
+    getServer,
+  );
+
+  runIntegrationTests(
+    'as a module',
+    async () => {
+      const app = await NestFactory.create(TestAppModuleWithModule);
+      await app.init();
+      return app;
+    },
+    getServer,
+  );
 });

--- a/libs/nest-problem-details-filter/tests/integration-tests.suite.ts
+++ b/libs/nest-problem-details-filter/tests/integration-tests.suite.ts
@@ -122,5 +122,21 @@ export function runIntegrationTests(
         instance: 'field-name',
       });
     });
+
+    it('should map business-specific exception with custom fields', async () => {
+      const response = await request(getServer(app))
+        .get('/api/test/business-error')
+        .expect(403);
+
+      expect(response.body).toEqual({
+        type: 'out-of-credit',
+        title: 'You do not have enough credit.',
+        status: 403,
+        detail: 'Your current balance is 30, but that costs 50.',
+        instance: '/account/12345/msgs/abc',
+        balance: 30,
+        accounts: ['/account/12345', '/account/67890'],
+      });
+    });
   });
 }

--- a/libs/nest-problem-details-filter/tests/test-app.module.ts
+++ b/libs/nest-problem-details-filter/tests/test-app.module.ts
@@ -72,6 +72,23 @@ export class TestController {
     }
     throw new HttpException(errorObj, parseInt(status, 10));
   }
+
+  @Get('business-error')
+  businessError(): void {
+    throw new HttpException(
+      {
+        message: 'You do not have enough credit.',
+        error: {
+          type: 'out-of-credit',
+          detail: 'Your current balance is 30, but that costs 50.',
+          instance: '/account/12345/msgs/abc',
+          balance: 30,
+          accounts: ['/account/12345', '/account/67890'],
+        },
+      },
+      403,
+    );
+  }
 }
 
 @Module({


### PR DESCRIPTION
- Fix `detail` extraction for nested error objects in HttpExceptionFilter
- Allow arbitrary custom fields in `IErrorDetail.error` via index signature
- Simplify constructor to accept only `HttpAdapterHost`, remove runtime check
- Handle unknown/unsupported HTTP status codes with proper fallbacks
- Add missing standard HTTP status codes to default error map
- Export [IProblemDetail](libs/nest-problem-details-filter/src/filters/http-exception.interface.ts:) and [IErrorDetail](libs/nest-problem-details-filter/src/filters/http-exception.interface.ts) from public API
- Refactor `objectExtras` to avoid wasteful overwrites via destructuring
- Re-add business-error integration test with custom fields
- Implement generic adapter integration test suite
- Make Express test explicitly use `ExpressAdapter`
- Tag v1.2.0