### PR TITLE
fix: resolve empty package on publish and export missing symbols

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,5 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run test:cov
+      - run: npm run build # Test build, ain't falling for #16 again
+      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm test
+      - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/libs/nest-problem-details-filter/package.json
+++ b/libs/nest-problem-details-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-problem-details-filter",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A NestJS exception filter to convert JSON responses to RFC-7807-compliant format. This standardizes HTTP responses and sets `Content-Type` to `application/problem+json`",
   "license": "MIT",
   "main": "dist/index.js",
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Fcmam5/nest-http-problem-details"
+    "url": "git+https://github.com/Fcmam5/nest-http-problem-details.git"
   },
   "author": "Abdeldjalil Fortas (Fcmam5)",
   "bugs": {
@@ -33,8 +33,7 @@
   },
   "scripts": {
     "build": "nest build",
-    "prepack": "rm -rf dist && npm run build",
-    "prepublish": "rm -rf dist && npm run build",
+    "prepublishOnly": "rm -rf dist && npm run build",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "lint:fix": "npm run lint -- --fix",

--- a/libs/nest-problem-details-filter/src/filters/constants.ts
+++ b/libs/nest-problem-details-filter/src/filters/constants.ts
@@ -2,7 +2,7 @@ export interface IDefaultHTTPErrors {
   [status: number]: string;
 }
 
-export const defaultHttpErrors: IDefaultHTTPErrors = {
+export const DEFAULT_HTTP_ERRORS: IDefaultHTTPErrors = {
   400: 'bad-request',
   401: 'unauthorized',
   402: 'payment-required',

--- a/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.filter.ts
@@ -8,7 +8,7 @@ import {
 import { HttpAdapterHost } from '@nestjs/core';
 import {
   BASE_PROBLEMS_URI_KEY,
-  defaultHttpErrors as _defaultHttpErrors,
+  DEFAULT_HTTP_ERRORS,
   HTTP_ERRORS_MAP_KEY,
   PROBLEM_CONTENT_TYPE,
 } from './constants';
@@ -22,7 +22,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     @Inject(BASE_PROBLEMS_URI_KEY)
     private baseUri = '',
     @Inject(HTTP_ERRORS_MAP_KEY)
-    private defaultHttpErrors = _defaultHttpErrors,
+    private defaultHttpErrors = DEFAULT_HTTP_ERRORS,
   ) {}
 
   catch(exception: HttpException, host: ArgumentsHost): void {

--- a/libs/nest-problem-details-filter/src/filters/http-exception.providers.ts
+++ b/libs/nest-problem-details-filter/src/filters/http-exception.providers.ts
@@ -1,6 +1,6 @@
 import { Provider } from '@nestjs/common';
 import {
-  defaultHttpErrors,
+  DEFAULT_HTTP_ERRORS,
   HTTP_ERRORS_MAP_KEY,
   BASE_PROBLEMS_URI_KEY,
   HTTP_EXCEPTION_FILTER_KEY,
@@ -14,7 +14,7 @@ export const BASE_PROBLEMS_URI: Provider = {
 
 export const HTTP_ERRORS_MAP: Provider = {
   provide: HTTP_ERRORS_MAP_KEY,
-  useValue: defaultHttpErrors,
+  useValue: DEFAULT_HTTP_ERRORS,
 };
 
 export const HTTP_EXCEPTION_FILTER: Provider = {

--- a/libs/nest-problem-details-filter/src/index.ts
+++ b/libs/nest-problem-details-filter/src/index.ts
@@ -3,6 +3,7 @@ export { HttpExceptionFilter } from './filters/http-exception.filter';
 
 export {
   BASE_PROBLEMS_URI_KEY,
+  DEFAULT_HTTP_ERRORS,
   HTTP_ERRORS_MAP_KEY,
   HTTP_EXCEPTION_FILTER_KEY,
   PROBLEM_CONTENT_TYPE,


### PR DESCRIPTION
- Add build step to main workflow to catch build failures before release
- Add build step to release workflow before publish
- Replace deprecated prepack/prepublish with prepublishOnly
- Rename defaultHttpErrors to DEFAULT_HTTP_ERRORS and re-export as defaultHttpErrors
- Update package.json version to 1.2.3