### PR TITLE
Add RFC 9457 Problem Details utilities for validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Make NestJS return [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (fo
 - **`Retry-After` header support** - Per RFC 9110 §10.2.3, opt-in via `ProblemDetailsException` or any `HttpException` subclass exposing `retryAfter`
 - **Swagger / OpenAPI decorator (optional)** - `@ApiProblemResponse()` via `nest-problem-details-filter/swagger` subpath auto-documents `application/problem+json` without forcing `@nestjs/swagger` on users who don't need it
 - **Docs / runtime alignment** - Shared resolvers guarantee OpenAPI examples match the wire format (status-to-type map, title fallbacks, base-URI resolution)
+- **Flexible validation error handling** - Three approaches from zero-config to full RFC 9457 JSON Pointer compliance (see [Validation errors](#validation-errors))
 - **Zero runtime dependencies** - Core filter has no runtime dependencies
 
 <!-- omit from toc --> 
@@ -30,6 +31,10 @@ Make NestJS return [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (fo
     - [Example response](#example-response)
     - [OpenAPI schema](#openapi-schema)
     - [Documentation](#documentation)
+    - [Validation errors](#validation-errors)
+      - [Approach 1 — Zero config](#approach-1--zero-config)
+      - [Approach 2 — Field-map via `BadRequestException`](#approach-2--field-map-via-badrequestexception)
+      - [Approach 3 — `ProblemDetailsException` (field-map or RFC pointer array)](#approach-3--problemdetailsexception-field-map-or-rfc-pointer-array)
   - [Development](#development)
     - [Tests](#tests)
     - [Mock app](#mock-app)
@@ -297,6 +302,87 @@ components:
 ### Documentation
 
 Check the [`docs/`](./docs/) folder for usage examples and the [OpenAPI schema](./docs/openapi.md).
+
+### Validation errors
+
+The filter ships three flexible approaches for surfacing `class-validator` validation errors — all using the `errors` RFC 9457 extension member (not `detail`, per §3.1.4).
+
+> **Peer dependency:** the helpers below require `class-validator` (already a NestJS validation standard). Install it alongside the filter:
+> ```bash
+> npm install class-validator
+> ```
+
+#### Approach 1 — Zero config
+
+Just register `ValidationPipe` + `HttpExceptionFilter`. The filter detects the `string[]` message Nest emits and moves it to `errors` automatically ([why not using `details` as array?](./docs/usage.md#validation-error-handling)):
+
+```json
+{
+  "type": "bad-request",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Bad Request",
+  "errors": [
+    "username must be longer than or equal to 3 characters",
+    "email must be an email"
+  ]
+}
+```
+
+#### Approach 2 — Field-map via `BadRequestException`
+
+Use `mapClassValidatorErrors()` in `exceptionFactory` for per-field grouping with dotted-path nesting:
+
+```ts
+import { mapClassValidatorErrors } from 'nest-problem-details-filter/class-validator-mappers';
+
+new ValidationPipe({
+  exceptionFactory: (e) =>
+    new BadRequestException({ message: 'Validation failed', errors: mapClassValidatorErrors(e) }),
+})
+```
+
+```json
+{
+  "type": "bad-request",
+  "title": "Validation failed",
+  "status": 400,
+  "errors": {
+    "email": ["must be an email"],
+    "address.street": ["should not be empty"]
+  }
+}
+```
+
+#### Approach 3 — `ProblemDetailsException` (field-map or RFC pointer array)
+
+Use `toValidationProblemDetails()` for a one-liner that returns a `ProblemDetailsException` directly:
+
+```ts
+import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator';
+
+// Field-map (default)
+new ValidationPipe({ exceptionFactory: (e) => toValidationProblemDetails(e) })
+
+// RFC 9457 JSON Pointer array
+new ValidationPipe({ exceptionFactory: (e) => toValidationProblemDetails(e, { usePointers: true }) })
+```
+
+Pointer format output:
+
+```json
+{
+  "type": "validation-error",
+  "title": "Validation Failed",
+  "status": 400,
+  "errors": [
+    { "detail": "must be an email", "pointer": "#/email" },
+    { "detail": "should not be empty", "pointer": "#/address/street" }
+  ]
+}
+```
+
+See [`docs/usage.md`](./docs/usage.md#validation-error-handling) for the full walkthrough including nested objects, custom validators, and all options.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ new ValidationPipe({
 Use `toValidationProblemDetails()` for a one-liner that returns a `ProblemDetailsException` directly:
 
 ```ts
-import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator';
+import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator-mappers';
 
 // Field-map (default)
 new ValidationPipe({ exceptionFactory: (e) => toValidationProblemDetails(e) })

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,29 @@
 # Usage Documentation
 
+- [Usage Documentation](#usage-documentation)
+  - [As a global filter](#as-a-global-filter)
+  - [As a module](#as-a-module)
+  - [Throwing exceptions](#throwing-exceptions)
+    - [Recommended: `ProblemDetailsException`](#recommended-problemdetailsexception)
+      - [Optional `type`](#optional-type)
+    - [Alternative: native `HttpException`](#alternative-native-httpexception)
+  - [Retry-After header](#retry-after-header)
+    - [With Nest's native exceptions](#with-nests-native-exceptions)
+  - [Swagger / OpenAPI](#swagger--openapi)
+    - [Aligning with `BASE_PROBLEMS_URI`](#aligning-with-base_problems_uri)
+    - [Aligning with `HTTP_ERRORS_MAP_KEY`](#aligning-with-http_errors_map_key)
+  - [Example responses](#example-responses)
+    - [Default Nest `NotFoundException` handler](#default-nest-notfoundexception-handler)
+    - [Throwing a `HttpException` with no parameters](#throwing-a-httpexception-with-no-parameters)
+    - [Throwing a `HttpException` with a title](#throwing-a-httpexception-with-a-title)
+    - [Throwing a `HttpException` with a title and description](#throwing-a-httpexception-with-a-title-and-description)
+  - [Validation error handling](#validation-error-handling)
+    - [Approach 1 — Zero config (default `ValidationPipe`)](#approach-1--zero-config-default-validationpipe)
+    - [Approach 2 — `BadRequestException` with `exceptionFactory`](#approach-2--badrequestexception-with-exceptionfactory)
+    - [Approach 3A — `ProblemDetailsException` with field-map (shorthand)](#approach-3a--problemdetailsexception-with-field-map-shorthand)
+    - [Approach 3B — `ProblemDetailsException` with RFC 9457 JSON Pointer array](#approach-3b--problemdetailsexception-with-rfc-9457-json-pointer-array)
+    - [Exported helpers summary](#exported-helpers-summary)
+
 ## As a global filter
 
 In `main.ts` add `app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost)))` as the following:
@@ -143,11 +167,11 @@ Both forms produce identical responses; prefer `ProblemDetailsException` for new
 
 Three input forms are accepted:
 
-| Type     | Meaning                                    | On-wire format                                |
-|----------|--------------------------------------------|-----------------------------------------------|
-| `number` | Non-negative delta-seconds                 | Integer string; fractional values rounded up  |
-| `Date`   | Absolute retry instant                     | IMF-fixdate via `Date.toUTCString()`          |
-| `string` | Caller-formatted, passed through unchanged | Whatever you supply (must be non-blank)       |
+| Type     | Meaning                                    | On-wire format                               |
+| -------- | ------------------------------------------ | -------------------------------------------- |
+| `number` | Non-negative delta-seconds                 | Integer string; fractional values rounded up |
+| `Date`   | Absolute retry instant                     | IMF-fixdate via `Date.toUTCString()`         |
+| `string` | Caller-formatted, passed through unchanged | Whatever you supply (must be non-blank)      |
 
 ```ts
 // Rate limiting — delta-seconds:
@@ -355,3 +379,177 @@ Content-Type: application/problem+json; charset=utf-8
   "detail": "Could not find any dragon with ID: 99"
 }
 ```
+
+---
+
+## Validation error handling
+
+The library supports three approaches for surfacing `class-validator` errors. Choose the one that fits your use case.
+
+> **Peer dependency:** these helpers require `class-validator` (already a NestJS validation standard). Install it alongside the filter:
+> ```bash
+> npm install class-validator
+> ```
+
+> **Why `errors` and not `detail`?**
+> RFC 9457 §3.1.4 states: _"Consumers SHOULD NOT parse the `detail` member for information; extensions are more suitable and less error-prone ways to obtain such information."_
+> All three approaches use the `errors` extension member, not `detail`.
+
+> **Why not `invalid-params`?**
+> `invalid-params` appeared only in an RFC 7807 example and was not standardised in RFC 9457. Avoid it.
+
+---
+
+### Approach 1 — Zero config (default `ValidationPipe`)
+
+Register `HttpExceptionFilter` as usual. When Nest's default `ValidationPipe` rejects a request it throws `BadRequestException` with `message: string[]`. The filter detects this and moves the array into the `errors` extension — **no extra configuration needed**.
+
+```ts
+// main.ts
+app.useGlobalPipes(new ValidationPipe());
+app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost)));
+```
+
+```json
+{
+  "type": "bad-request",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Bad Request",
+  "errors": [
+    "username must be longer than or equal to 3 characters",
+    "email must be an email",
+    "address.street should not be empty"
+  ]
+}
+```
+
+Messages are flat (no field grouping) because Nest's default pipe does not expose field keys in its output.
+
+---
+
+### Approach 2 — `BadRequestException` with `exceptionFactory`
+
+Use `mapClassValidatorErrors()` inside `exceptionFactory` to group messages by field name, then throw Nest's built-in `BadRequestException`. The filter picks up the `errors` object and passes it through.
+
+```ts
+import { mapClassValidatorErrors } from 'nest-problem-details-filter/class-validator-mappers';
+
+app.useGlobalPipes(
+  new ValidationPipe({
+    exceptionFactory: (validationErrors) =>
+      new BadRequestException({
+        message: 'Validation failed',
+        errors: mapClassValidatorErrors(validationErrors),
+      }),
+  }),
+);
+```
+
+```json
+{
+  "type": "bad-request",
+  "title": "Validation failed",
+  "status": 400,
+  "errors": {
+    "username": ["must be longer than or equal to 3 characters"],
+    "email": ["must be an email"],
+    "address.street": ["should not be empty"],
+    "address.city": ["should not be empty"]
+  }
+}
+```
+
+Nested objects are flattened with dotted-path keys (e.g. `address.street`). Custom validator messages appear under the correct field key just like built-in constraints.
+
+---
+
+### Approach 3A — `ProblemDetailsException` with field-map (shorthand)
+
+Use `toValidationProblemDetails()` for the shortest possible factory. It wraps `mapClassValidatorErrors()` and builds a fully-formed `ProblemDetailsException` in one call.
+
+```ts
+import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator';
+
+app.useGlobalPipes(
+  new ValidationPipe({
+    exceptionFactory: (e) => toValidationProblemDetails(e),
+  }),
+);
+```
+
+```json
+{
+  "type": "validation-error",
+  "title": "Validation Failed",
+  "status": 400,
+  "errors": {
+    "username": ["must be longer than or equal to 3 characters"],
+    "address.city": ["should not be empty"]
+  }
+}
+```
+
+You can override the defaults:
+
+```ts
+exceptionFactory: (e) =>
+  toValidationProblemDetails(e, {
+    status: 422,
+    title: 'Unprocessable Entity',
+    type: 'unprocessable-entity',
+  })
+```
+
+---
+
+### Approach 3B — `ProblemDetailsException` with RFC 9457 JSON Pointer array
+
+Pass `{ usePointers: true }` to `toValidationProblemDetails()` to get strict RFC 9457 compliance. Each violation becomes a `{ detail, pointer }` object where `pointer` is a JSON Pointer (`#/field` or `#/nested/field`).
+
+```ts
+import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator';
+
+app.useGlobalPipes(
+  new ValidationPipe({
+    exceptionFactory: (e) => toValidationProblemDetails(e, { usePointers: true }),
+  }),
+);
+```
+
+```json
+{
+  "type": "validation-error",
+  "title": "Validation Failed",
+  "status": 400,
+  "errors": [
+    { "detail": "must be longer than or equal to 3 characters", "pointer": "#/username" },
+    { "detail": "must be an email", "pointer": "#/email" },
+    { "detail": "should not be empty", "pointer": "#/address/street" }
+  ]
+}
+```
+
+You can also build the pointer array manually via `mapToPointerErrors()` if you need custom filtering or sorting:
+
+```ts
+import { mapToPointerErrors, ProblemDetailsException } from 'nest-problem-details-filter/class-validator-mappers';
+
+exceptionFactory: (validationErrors) =>
+  new ProblemDetailsException({
+    status: 400,
+    title: 'Validation Failed',
+    type: 'validation-error',
+    errors: mapToPointerErrors(validationErrors),
+  })
+```
+
+---
+
+### Exported helpers summary
+
+| Export                                         | Returns                    | Use case                                                                        |
+| ---------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `mapClassValidatorErrors(errors)`              | `Record<string, string[]>` | Build a field-map to pass to `BadRequestException` or `ProblemDetailsException` |
+| `mapToPointerErrors(errors)`                   | `PointerError[]`           | Build an RFC 9457 pointer array manually                                        |
+| `toValidationProblemDetails(errors, options?)` | `ProblemDetailsException`  | One-liner `exceptionFactory` for approaches 3A and 3B                           |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -469,7 +469,7 @@ Nested objects are flattened with dotted-path keys (e.g. `address.street`). Cust
 Use `toValidationProblemDetails()` for the shortest possible factory. It wraps `mapClassValidatorErrors()` and builds a fully-formed `ProblemDetailsException` in one call.
 
 ```ts
-import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator';
+import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator-mappers';
 
 app.useGlobalPipes(
   new ValidationPipe({
@@ -508,7 +508,7 @@ exceptionFactory: (e) =>
 Pass `{ usePointers: true }` to `toValidationProblemDetails()` to get strict RFC 9457 compliance. Each violation becomes a `{ detail, pointer }` object where `pointer` is a JSON Pointer (`#/field` or `#/nested/field`).
 
 ```ts
-import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator';
+import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator-mappers';
 
 app.useGlobalPipes(
   new ValidationPipe({

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     'dist/',
     'src/index.ts',
     'src/swagger/index.ts',
+    'src/class-validator-mappers/index.ts',
   ],
   coverageThreshold: {
     global: { branches: 99, functions: 99, lines: 99, statements: 99 },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "./swagger": {
       "types": "./dist/swagger/index.d.ts",
       "default": "./dist/swagger/index.js"
+    },
+    "./class-validator-mappers": {
+      "types": "./dist/class-validator-mappers/index.d.ts",
+      "default": "./dist/class-validator-mappers/index.js"
     }
   },
   "files": [
@@ -67,6 +71,8 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",
     "@types/supertest": "^6.0.3",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
@@ -86,10 +92,14 @@
   "peerDependencies": {
     "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@nestjs/swagger": "^9.0.0 || ^10.0.0 || ^11.0.0"
+    "@nestjs/swagger": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "class-validator": "^0.14.0 || ^0.15.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/swagger": {
+      "optional": true
+    },
+    "class-validator": {
       "optional": true
     }
   }

--- a/src/class-validator-mappers/index.ts
+++ b/src/class-validator-mappers/index.ts
@@ -1,0 +1,6 @@
+export {
+  mapClassValidatorErrors,
+  mapToPointerErrors,
+  toValidationProblemDetails,
+  PointerError,
+} from './map-class-validator-errors';

--- a/src/class-validator-mappers/map-class-validator-errors.spec.ts
+++ b/src/class-validator-mappers/map-class-validator-errors.spec.ts
@@ -1,0 +1,286 @@
+import {
+  mapClassValidatorErrors,
+  mapToPointerErrors,
+  toValidationProblemDetails,
+} from './map-class-validator-errors';
+import { ProblemDetailsException } from '../exception/problem-details.exception';
+
+describe('mapClassValidatorErrors', () => {
+  it('returns empty object for empty input', () => {
+    expect(mapClassValidatorErrors([])).toEqual({});
+  });
+
+  it('maps a single property with a single constraint', () => {
+    expect(
+      mapClassValidatorErrors([
+        {
+          property: 'email',
+          constraints: { isEmail: 'email must be an email' },
+        },
+      ]),
+    ).toEqual({ email: ['email must be an email'] });
+  });
+
+  it('maps a single property with multiple constraints', () => {
+    expect(
+      mapClassValidatorErrors([
+        {
+          property: 'name',
+          constraints: {
+            isNotEmpty: 'name should not be empty',
+            minLength: 'name must be longer than or equal to 3 characters',
+          },
+        },
+      ]),
+    ).toEqual({
+      name: [
+        'name should not be empty',
+        'name must be longer than or equal to 3 characters',
+      ],
+    });
+  });
+
+  it('maps multiple top-level properties', () => {
+    expect(
+      mapClassValidatorErrors([
+        {
+          property: 'email',
+          constraints: { isEmail: 'email must be an email' },
+        },
+        {
+          property: 'password',
+          constraints: { minLength: 'password must be at least 8 characters' },
+        },
+      ]),
+    ).toEqual({
+      email: ['email must be an email'],
+      password: ['password must be at least 8 characters'],
+    });
+  });
+
+  it('flattens nested object errors with dotted-path keys', () => {
+    expect(
+      mapClassValidatorErrors([
+        {
+          property: 'address',
+          children: [
+            {
+              property: 'street',
+              constraints: { isNotEmpty: 'street should not be empty' },
+            },
+            {
+              property: 'city',
+              constraints: { isString: 'city must be a string' },
+            },
+          ],
+        },
+      ]),
+    ).toEqual({
+      'address.street': ['street should not be empty'],
+      'address.city': ['city must be a string'],
+    });
+  });
+
+  it('flattens deeply nested errors', () => {
+    expect(
+      mapClassValidatorErrors([
+        {
+          property: 'billing',
+          children: [
+            {
+              property: 'address',
+              children: [
+                {
+                  property: 'zip',
+                  constraints: { matches: 'zip must be a valid postal code' },
+                },
+              ],
+            },
+          ],
+        },
+      ]),
+    ).toEqual({ 'billing.address.zip': ['zip must be a valid postal code'] });
+  });
+
+  it('includes custom validator constraint messages', () => {
+    expect(
+      mapClassValidatorErrors([
+        {
+          property: 'username',
+          constraints: {
+            IsNotReservedUsername: 'username "admin" is a reserved username',
+          },
+        },
+      ]),
+    ).toEqual({ username: ['username "admin" is a reserved username'] });
+  });
+
+  it('skips properties with no constraints and no children', () => {
+    expect(
+      mapClassValidatorErrors([
+        { property: 'ghost' },
+        {
+          property: 'email',
+          constraints: { isEmail: 'email must be an email' },
+        },
+      ]),
+    ).toEqual({ email: ['email must be an email'] });
+  });
+
+  it('handles a property that has both constraints and children', () => {
+    expect(
+      mapClassValidatorErrors([
+        {
+          property: 'profile',
+          constraints: { isObject: 'profile must be an object' },
+          children: [
+            {
+              property: 'bio',
+              constraints: { maxLength: 'bio must be at most 160 characters' },
+            },
+          ],
+        },
+      ]),
+    ).toEqual({
+      profile: ['profile must be an object'],
+      'profile.bio': ['bio must be at most 160 characters'],
+    });
+  });
+});
+
+describe('mapToPointerErrors', () => {
+  it('returns empty array for empty input', () => {
+    expect(mapToPointerErrors([])).toEqual([]);
+  });
+
+  it('produces { detail, pointer } entries for top-level constraints', () => {
+    expect(
+      mapToPointerErrors([
+        {
+          property: 'email',
+          constraints: { isEmail: 'email must be an email' },
+        },
+        {
+          property: 'age',
+          constraints: { isPositive: 'must be a positive integer' },
+        },
+      ]),
+    ).toEqual([
+      { detail: 'email must be an email', pointer: '#/email' },
+      { detail: 'must be a positive integer', pointer: '#/age' },
+    ]);
+  });
+
+  it('converts dotted nested paths to slash-separated JSON Pointer segments', () => {
+    expect(
+      mapToPointerErrors([
+        {
+          property: 'address',
+          children: [
+            {
+              property: 'street',
+              constraints: { isNotEmpty: 'street should not be empty' },
+            },
+          ],
+        },
+      ]),
+    ).toEqual([
+      { detail: 'street should not be empty', pointer: '#/address/street' },
+    ]);
+  });
+
+  it('flattens multiple constraints into multiple pointer entries', () => {
+    const result = mapToPointerErrors([
+      {
+        property: 'name',
+        constraints: {
+          isNotEmpty: 'name should not be empty',
+          minLength: 'name must be at least 3 characters',
+        },
+      },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.pointer === '#/name')).toBe(true);
+  });
+
+  it('includes custom validator messages', () => {
+    expect(
+      mapToPointerErrors([
+        {
+          property: 'username',
+          constraints: {
+            IsNotReservedUsername: 'username "admin" is a reserved username',
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        detail: 'username "admin" is a reserved username',
+        pointer: '#/username',
+      },
+    ]);
+  });
+});
+
+describe('toValidationProblemDetails', () => {
+  const errors = [
+    { property: 'email', constraints: { isEmail: 'email must be an email' } },
+    {
+      property: 'address',
+      children: [
+        {
+          property: 'city',
+          constraints: { isNotEmpty: 'city should not be empty' },
+        },
+      ],
+    },
+  ];
+
+  it('returns a ProblemDetailsException instance', () => {
+    expect(toValidationProblemDetails(errors)).toBeInstanceOf(
+      ProblemDetailsException,
+    );
+  });
+
+  it('defaults to status 400, title "Validation Failed", type "validation-error"', () => {
+    const ex = toValidationProblemDetails(errors);
+    const body = ex.getResponse() as Record<string, unknown>;
+    expect(ex.getStatus()).toBe(400);
+    expect(body.message).toBe('Validation Failed');
+    const err = body.error as Record<string, unknown>;
+    expect(err.type).toBe('validation-error');
+  });
+
+  it('produces field-map errors by default', () => {
+    const ex = toValidationProblemDetails(errors);
+    const body = ex.getResponse() as Record<string, unknown>;
+    const err = body.error as Record<string, unknown>;
+    expect(err.errors).toEqual({
+      email: ['email must be an email'],
+      'address.city': ['city should not be empty'],
+    });
+  });
+
+  it('produces pointer-array errors when usePointers: true', () => {
+    const ex = toValidationProblemDetails(errors, { usePointers: true });
+    const body = ex.getResponse() as Record<string, unknown>;
+    const err = body.error as Record<string, unknown>;
+    expect(Array.isArray(err.errors)).toBe(true);
+    (err.errors as Array<{ pointer: string }>).forEach((e) =>
+      expect(e.pointer).toMatch(/^#\//),
+    );
+  });
+
+  it('accepts custom status, title, and type', () => {
+    const ex = toValidationProblemDetails(errors, {
+      status: 422,
+      title: 'Unprocessable Entity',
+      type: 'unprocessable',
+    });
+    const body = ex.getResponse() as Record<string, unknown>;
+    expect(ex.getStatus()).toBe(422);
+    expect(body.message).toBe('Unprocessable Entity');
+    const err = body.error as Record<string, unknown>;
+    expect(err.type).toBe('unprocessable');
+  });
+});

--- a/src/class-validator-mappers/map-class-validator-errors.ts
+++ b/src/class-validator-mappers/map-class-validator-errors.ts
@@ -1,0 +1,131 @@
+import { HttpStatus } from '@nestjs/common';
+import { ValidationError } from 'class-validator';
+import {
+  ProblemDetailsException,
+  ProblemDetailsInput,
+} from '../exception/problem-details.exception';
+
+/** RFC 9457 §3 JSON Pointer error entry. */
+export interface PointerError {
+  detail: string;
+  pointer: string;
+}
+
+/**
+ * Flatten a `class-validator` `ValidationError[]` tree into a DX-friendly
+ * field-map: `{ "field": ["msg1", "msg2"], "nested.field": ["msg"] }`.
+ *
+ * - Top-level property → key is the property name.
+ * - Nested property → key is a dotted path (`address.street`).
+ * - Multiple constraints on the same property → multiple messages in the array.
+ * - Custom validator constraints are included just like built-in ones.
+ *
+ * @param errors  Array returned by `class-validator` (e.g. from Nest's
+ *                `ValidationPipe` `exceptionFactory` parameter).
+ * @param prefix  Internal path prefix for recursive flattening; leave empty.
+ * @returns       `Record<string, string[]>` mapping field path → messages.
+ */
+export function mapClassValidatorErrors(
+  errors: ValidationError[],
+  prefix = '',
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+
+  for (const error of errors) {
+    const key = prefix ? `${prefix}.${error.property}` : error.property;
+
+    if (error.constraints && Object.keys(error.constraints).length > 0) {
+      result[key] = Object.values(error.constraints);
+    }
+
+    if (error.children && error.children.length > 0) {
+      Object.assign(result, mapClassValidatorErrors(error.children, key));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert a `class-validator` `ValidationError[]` into an RFC 9457-compliant
+ * array of `{ detail, pointer }` objects using JSON Pointer notation.
+ *
+ * Nested properties produce dotted paths converted to JSON Pointer segments
+ * (e.g. `address.street` → `#/address/street`).
+ *
+ * Use this when you need strict RFC 9457 §3 compliance and your clients
+ * expect the canonical `errors` array format.
+ *
+ * @param errors  Array returned by `class-validator`.
+ * @param prefix  Internal prefix for recursive flattening; leave empty.
+ * @returns       `PointerError[]` — each violation as `{ detail, pointer }`.
+ */
+export function mapToPointerErrors(
+  errors: ValidationError[],
+  prefix = '',
+): PointerError[] {
+  const result: PointerError[] = [];
+
+  for (const error of errors) {
+    const path = prefix ? `${prefix}.${error.property}` : error.property;
+    const pointer = '#/' + path.replace(/\./g, '/');
+
+    if (error.constraints) {
+      for (const detail of Object.values(error.constraints)) {
+        result.push({ detail, pointer });
+      }
+    }
+
+    if (error.children && error.children.length > 0) {
+      result.push(...mapToPointerErrors(error.children, path));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Build a `ProblemDetailsException` from a `class-validator` error array in
+ * one call — the shortest path from `exceptionFactory` to a fully-formed
+ * RFC 9457 response.
+ *
+ * By default it produces a DX-friendly field-map (`errors: Record<string,string[]>`).
+ * Pass `{ usePointers: true }` to switch to RFC 9457 JSON Pointer format.
+ *
+ * @example — field map (default):
+ * ```ts
+ * new ValidationPipe({
+ *   exceptionFactory: (e) => toValidationProblemDetails(e),
+ * })
+ * ```
+ *
+ * @example — RFC 9457 JSON Pointer:
+ * ```ts
+ * new ValidationPipe({
+ *   exceptionFactory: (e) => toValidationProblemDetails(e, { usePointers: true }),
+ * })
+ * ```
+ */
+export function toValidationProblemDetails(
+  validationErrors: ValidationError[],
+  options?: {
+    usePointers?: boolean;
+    status?: number;
+    title?: string;
+    type?: string;
+  },
+): ProblemDetailsException {
+  const {
+    usePointers = false,
+    status = HttpStatus.BAD_REQUEST,
+    title = 'Validation Failed',
+    type = 'validation-error',
+  } = options ?? {};
+
+  const errors = usePointers
+    ? mapToPointerErrors(validationErrors)
+    : mapClassValidatorErrors(validationErrors);
+
+  const input: ProblemDetailsInput = { status, title, type, errors };
+  return new ProblemDetailsException(input);
+}

--- a/src/filter/http-exception.filter.spec.ts
+++ b/src/filter/http-exception.filter.spec.ts
@@ -469,6 +469,107 @@ describe('HttpExceptionFilter', () => {
     });
   });
 
+  describe('Validation error handling', () => {
+    const status = HttpStatus.BAD_REQUEST;
+
+    describe('Approach 1 — default ValidationPipe (string[] message)', () => {
+      it('puts message array into errors and resolves title from status', () => {
+        filter.catch(
+          new BadRequestException({
+            message: [
+              'email must be an email',
+              'name must be longer than or equal to 3 characters',
+            ],
+            error: 'Bad Request',
+            statusCode: status,
+          }),
+          mockArgumentsHost,
+        );
+
+        assertResponse(status, {
+          type: 'bad-request',
+          title: 'Bad Request',
+          status,
+          detail: 'Bad Request',
+          errors: [
+            'email must be an email',
+            'name must be longer than or equal to 3 characters',
+          ],
+        } as unknown as IProblemDetail);
+      });
+
+      it('omits errors when message array is empty', () => {
+        filter.catch(
+          new BadRequestException({
+            message: [],
+            error: 'Bad Request',
+            statusCode: status,
+          }),
+          mockArgumentsHost,
+        );
+
+        const call = (mockHttpAdapterHost.httpAdapter.reply as jest.Mock).mock
+          .calls[0][1];
+        expect(call).not.toHaveProperty('errors');
+      });
+    });
+
+    describe('Approach 2 — BadRequestException with explicit errors field-map', () => {
+      it('passes errors object through to response', () => {
+        filter.catch(
+          new BadRequestException({
+            message: 'Validation failed',
+            errors: {
+              email: ['must be an email'],
+              'address.city': ['should not be empty'],
+            },
+            statusCode: status,
+          }),
+          mockArgumentsHost,
+        );
+
+        assertResponse(status, {
+          type: 'bad-request',
+          title: 'Validation failed',
+          status,
+          errors: {
+            email: ['must be an email'],
+            'address.city': ['should not be empty'],
+          },
+        } as unknown as IProblemDetail);
+      });
+    });
+
+    describe('Approach 3B — RFC 9457 JSON Pointer array via ProblemDetailsException', () => {
+      it('passes errors pointer array through to response', () => {
+        filter.catch(
+          new HttpException(
+            {
+              message: 'Validation Failed',
+              errors: [
+                { detail: 'must be an email', pointer: '#/email' },
+                { detail: 'must be a positive integer', pointer: '#/age' },
+              ],
+              statusCode: status,
+            },
+            status,
+          ),
+          mockArgumentsHost,
+        );
+
+        assertResponse(status, {
+          type: 'bad-request',
+          title: 'Validation Failed',
+          status,
+          errors: [
+            { detail: 'must be an email', pointer: '#/email' },
+            { detail: 'must be a positive integer', pointer: '#/age' },
+          ],
+        } as unknown as IProblemDetail);
+      });
+    });
+  });
+
   function assertResponse(
     expectedStatus: number,
     expectedJson: IProblemDetail,

--- a/src/filter/http-exception.filter.ts
+++ b/src/filter/http-exception.filter.ts
@@ -43,21 +43,26 @@ export class HttpExceptionFilter implements ExceptionFilter {
       | IExceptionResponse;
 
     let title: string | undefined;
-    let detail;
+    let detail: string | undefined;
     let type: string | undefined;
-    let objectExtras;
+    let objectExtras: Record<string, unknown> | undefined;
+    let errors: unknown;
 
     if (typeof errorResponse === 'string') {
       title = errorResponse;
     } else {
-      // TODO #26: `errorResponse.message` may be `string[]` when Nest's
-      // ValidationPipe is used, which produces a non-string `title` and
-      // violates the RFC 9457 schema. The planned fix keeps `title` as the
-      // status reason phrase and moves the array to the `invalid-params`
-      // extension member (RFC 9457 §3 canonical example). See TODO.md #6
-      // and #13 (`class-validator` mapper, gh#23). Until then, callers must
-      // ensure `message` is a string.
-      title = errorResponse.message;
+      const message = errorResponse.message;
+
+      if (Array.isArray(message) && message.length > 0) {
+        // Approach 1: Nest's default ValidationPipe emits a flat string[].
+        // Per RFC 9457 §3.1.4 consumers SHOULD NOT parse `detail` for
+        // information — put the array in `errors` instead.
+        title = undefined; // resolves to HTTP status reason phrase
+        errors = message;
+      } else if (typeof message === 'string') {
+        title = message;
+      }
+
       if (typeof errorResponse.error === 'string') {
         detail = errorResponse.error;
       } else if (isErrorObject(errorResponse.error)) {
@@ -66,15 +71,25 @@ export class HttpExceptionFilter implements ExceptionFilter {
         detail = _detail;
         objectExtras = rest;
       }
+
+      // Approaches 2 & 3: caller supplied a structured `errors` value
+      // (Record<string,string[]> field-map or RFC pointer array). Pass through.
+      if (errorResponse.errors !== undefined) {
+        errors = errorResponse.errors;
+      }
     }
 
-    const responseBody = {
+    const responseBody: Record<string, unknown> = {
       ...objectExtras,
       type: this.resolveType(type, status),
       title: resolveProblemTitle(title, status),
       status,
       detail,
     };
+
+    if (errors !== undefined) {
+      responseBody['errors'] = errors;
+    }
 
     httpAdapter.setHeader(response, 'Content-Type', PROBLEM_CONTENT_TYPE);
     this.applyRetryAfter(response, exception);

--- a/src/filter/interfaces.ts
+++ b/src/filter/interfaces.ts
@@ -1,6 +1,8 @@
-// As specified in RFC 9457 §3 (formerly RFC 7807 §3.1).
-// https://datatracker.ietf.org/doc/html/rfc9457#section-3
-// https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+/**
+ * As specified in RFC 9457 §3 (formerly RFC 7807 §3.1).
+ * https://datatracker.ietf.org/doc/html/rfc9457#section-3
+ * https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+ */
 export interface IProblemDetail {
   status: number;
   title: string;
@@ -20,10 +22,17 @@ export interface IErrorDetail {
   };
 }
 
-// Shape of the payload returned by `HttpException.getResponse()` when not a
-// plain string. Mirrors NestJS's internal exception shape.
+/**
+ * Shape of the payload returned by `HttpException.getResponse()` when not a
+ * plain string. Mirrors NestJS's internal exception shape.
+ *
+ * `message` may be a `string[]` when Nest's default `ValidationPipe` is used.
+ * `errors` carries structured validation errors when set by the caller:
+ * either a `Record<string, string[]>` field-map or a RFC 9457 pointer array.
+ */
 export interface IExceptionResponse {
-  message: string;
+  message: string | string[];
   error?: string | IErrorDetail['error'];
+  errors?: unknown;
   statusCode: number;
 }

--- a/tests/dto/create-user.dto.ts
+++ b/tests/dto/create-user.dto.ts
@@ -1,0 +1,58 @@
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  MinLength,
+  ValidateNested,
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+// Custom validator example: ensures value is not 'admin'
+function IsNotReservedUsername(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'IsNotReservedUsername',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          return typeof value === 'string' && value.toLowerCase() !== 'admin';
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} "${args.value}" is a reserved username`;
+        },
+      },
+    });
+  };
+}
+
+// Nested DTO
+export class AddressDto {
+  @IsString()
+  @IsNotEmpty()
+  street!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  city!: string;
+}
+
+// Root DTO — flat fields + nested object + custom validator
+export class CreateUserDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(3)
+  @IsNotReservedUsername()
+  username!: string;
+
+  @IsEmail()
+  email!: string;
+
+  @ValidateNested()
+  @Type(() => AddressDto)
+  address!: AddressDto;
+}

--- a/tests/integration-tests.suite.ts
+++ b/tests/integration-tests.suite.ts
@@ -140,6 +140,168 @@ export function runIntegrationTests(
       });
     });
 
+    describe('Validation errors', () => {
+      const invalidBody = {
+        username: 'a',
+        email: 'not-an-email',
+        address: { street: '', city: '' },
+      };
+
+      const adminBody = {
+        username: 'admin',
+        email: 'admin@example.com',
+        address: { street: '1 Main St', city: 'Paris' },
+      };
+
+      describe('Approach 1 — default ValidationPipe (flat string[] → errors array)', () => {
+        it('returns a flat errors string[] for invalid body', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/default')
+            .send(invalidBody)
+            .expect(400);
+
+          expect(response.body.type).toBe('bad-request');
+          expect(response.body.title).toBe('Bad Request');
+          expect(response.body.status).toBe(400);
+          expect(Array.isArray(response.body.errors)).toBe(true);
+          expect(response.body.errors.length).toBeGreaterThan(0);
+          response.body.errors.forEach((e: unknown) =>
+            expect(typeof e).toBe('string'),
+          );
+        });
+
+        it('returns errors containing nested field messages', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/default')
+            .send(invalidBody)
+            .expect(400);
+
+          const msgs: string[] = response.body.errors;
+          expect(msgs.some((m) => m.includes('email'))).toBe(true);
+          expect(
+            msgs.some(
+              (m) =>
+                m.includes('street') ||
+                m.includes('city') ||
+                m.includes('address'),
+            ),
+          ).toBe(true);
+        });
+
+        it('fires the custom IsNotReservedUsername validator', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/default')
+            .send(adminBody)
+            .expect(400);
+
+          const msgs: string[] = response.body.errors;
+          expect(msgs.some((m) => m.includes('reserved'))).toBe(true);
+        });
+      });
+
+      describe('Approach 2 — BadRequestException + exceptionFactory', () => {
+        it('returns a field-map errors object', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/bad-request-factory')
+            .send(invalidBody)
+            .expect(400);
+
+          expect(response.body.type).toBe('bad-request');
+          expect(response.body.title).toBe('Validation failed');
+          expect(response.body.status).toBe(400);
+          expect(response.body.errors).toBeDefined();
+          expect(typeof response.body.errors).toBe('object');
+          expect(Array.isArray(response.body.errors)).toBe(false);
+        });
+
+        it('groups messages by field name including nested dotted paths', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/bad-request-factory')
+            .send(invalidBody)
+            .expect(400);
+
+          const errors: Record<string, string[]> = response.body.errors;
+          expect(errors['email']).toBeDefined();
+          expect(Array.isArray(errors['email'])).toBe(true);
+          expect(
+            errors['address.street'] ?? errors['address.city'],
+          ).toBeDefined();
+        });
+
+        it('includes custom validator error under correct field key', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/bad-request-factory')
+            .send(adminBody)
+            .expect(400);
+
+          const errors: Record<string, string[]> = response.body.errors;
+          expect(errors['username']).toBeDefined();
+          expect(errors['username'].some((m) => m.includes('reserved'))).toBe(
+            true,
+          );
+        });
+      });
+
+      describe('Approach 3A — ProblemDetailsException + field-map', () => {
+        it('returns type validation-error with field-map errors', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/problem-details-field-map')
+            .send(invalidBody)
+            .expect(400);
+
+          expect(response.body.type).toBe('validation-error');
+          expect(response.body.title).toBe('Validation Failed');
+          expect(response.body.status).toBe(400);
+          expect(typeof response.body.errors).toBe('object');
+          expect(Array.isArray(response.body.errors)).toBe(false);
+        });
+
+        it('groups by field including nested dotted paths', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/problem-details-field-map')
+            .send(invalidBody)
+            .expect(400);
+
+          const errors: Record<string, string[]> = response.body.errors;
+          expect(errors['email']).toBeDefined();
+          expect(
+            errors['address.street'] ?? errors['address.city'],
+          ).toBeDefined();
+        });
+      });
+
+      describe('Approach 3B — ProblemDetailsException + RFC 9457 JSON Pointer array', () => {
+        it('returns an array with detail and pointer for each violation', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/problem-details-json-pointer')
+            .send(invalidBody)
+            .expect(400);
+
+          expect(response.body.type).toBe('validation-error');
+          expect(response.body.title).toBe('Validation Failed');
+          expect(response.body.status).toBe(400);
+          expect(Array.isArray(response.body.errors)).toBe(true);
+          response.body.errors.forEach((e: unknown) => {
+            expect(e).toHaveProperty('detail');
+            expect(e).toHaveProperty('pointer');
+          });
+        });
+
+        it('pointer values use JSON Pointer format (#/field)', async () => {
+          const response = await request(getServer(app))
+            .post('/api/test/validation/problem-details-json-pointer')
+            .send(invalidBody)
+            .expect(400);
+
+          const pointers: string[] = response.body.errors.map(
+            (e: { pointer: string }) => e.pointer,
+          );
+          expect(pointers.some((p) => p.startsWith('#/'))).toBe(true);
+          expect(pointers.some((p) => p === '#/email')).toBe(true);
+        });
+      });
+    });
+
     describe('Retry-After header (RFC 9110 §10.2.3)', () => {
       it('sets Retry-After: <seconds> for 429 with numeric retryAfter', async () => {
         const response = await request(getServer(app))

--- a/tests/test-app.module.ts
+++ b/tests/test-app.module.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Body,
   Controller,
   ForbiddenException,
   Get,
@@ -7,8 +8,11 @@ import {
   Module,
   NotFoundException,
   Param,
+  Post,
   Query,
   ServiceUnavailableException,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import {
@@ -16,7 +20,27 @@ import {
   HTTP_EXCEPTION_FILTER_KEY,
   ProblemDetailsException,
 } from '../src';
+import {
+  mapClassValidatorErrors,
+  toValidationProblemDetails,
+} from '../src/class-validator-mappers';
+import { CreateUserDto } from './dto/create-user.dto';
 import { ApiProblemResponse } from '../src/swagger';
+import { ApiBody } from '@nestjs/swagger';
+
+// Shared @ApiBody decorator for the CreateUserDto validation endpoints.
+const CreateUserDtoBodyExamples = ApiBody({
+  type: CreateUserDto,
+  examples: {
+    badDto: {
+      summary: 'Invalid username and email',
+      value: {
+        username: 'admin',
+        email: 'invalid-email',
+      },
+    },
+  },
+});
 
 // Fixed instant used by Retry-After Date integration test.
 export const MAINTENANCE_RETRY_AT = new Date('2026-04-30T06:00:00Z');
@@ -197,6 +221,70 @@ export class TestController {
     }
     throw new MaintenanceException(300);
   }
+
+  // Approach 1 — Zero config: default ValidationPipe emits string[].
+  // The filter puts the flat string[] in `errors`.
+  @Post('validation/default')
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+    }),
+  )
+  @CreateUserDtoBodyExamples
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  validationDefault(@Body() _dto: CreateUserDto): void {
+    // Body is intentionally unused — we only care about the validation error.
+  }
+
+  // Approach 2 — Custom exceptionFactory with BadRequestException.
+  // Uses mapClassValidatorErrors to build a field-map and passes it via the
+  // standard BadRequestException so the filter picks up `errors`.
+  @Post('validation/bad-request-factory')
+  @CreateUserDtoBodyExamples
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      exceptionFactory: (validationErrors) => {
+        return new BadRequestException({
+          message: 'Validation failed',
+          errors: mapClassValidatorErrors(validationErrors),
+        });
+      },
+    }),
+  )
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  validationBadRequestFactory(@Body() _dto: CreateUserDto): void {}
+
+  // Approach 3A — ProblemDetailsException with field-map errors.
+  // Uses toValidationProblemDetails() shorthand.
+  @Post('validation/problem-details-field-map')
+  @CreateUserDtoBodyExamples
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      exceptionFactory: (e) => toValidationProblemDetails(e),
+    }),
+  )
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  validationProblemDetailsFieldMap(@Body() _dto: CreateUserDto): void {}
+
+  // Approach 3B — ProblemDetailsException with RFC 9457 JSON Pointer array.
+  // Uses toValidationProblemDetails({ usePointers: true }) shorthand.
+  @Post('validation/problem-details-json-pointer')
+  @CreateUserDtoBodyExamples
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      exceptionFactory: (e) =>
+        toValidationProblemDetails(e, { usePointers: true }),
+    }),
+  )
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  validationProblemDetailsJsonPointer(@Body() _dto: CreateUserDto): void {}
 }
 
 @Module({


### PR DESCRIPTION

- mapClassValidatorErrors(): field-map with dotted-path nesting
- mapToPointerErrors(): RFC 9457 JSON Pointer array
- toValidationProblemDetails(): one-liner ProblemDetailsException builder
- Export via ./class-validator-mappers subpath (peer dep: class-validator)
- Filter auto-detects string[] ValidationPipe messages → errors extension (fixes #26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three validation error-handling approaches for class-validator integration: zero-config string array mapping, field-map conversion, and RFC 9457-compatible JSON Pointer format.

* **Documentation**
  * Added comprehensive validation error handling guide with examples and helper functions for all three supported approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->