### PR TITLE
feat: add `suppressDetail` to hide sensitive error details in prd

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Make NestJS return [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (fo
   - [Features](#features)
   - [Usage](#usage)
     - [As a global filter](#as-a-global-filter)
+      - [Suppressing `detail` in production](#suppressing-detail-in-production)
     - [As a module](#as-a-module)
     - [Throwing exceptions](#throwing-exceptions)
       - [`Retry-After` header](#retry-after-header)
@@ -97,6 +98,46 @@ Will return:
   "detail": "Could not find any dragon with ID: 99"
 }
 ```
+
+#### Suppressing `detail` in production
+
+> **Recommended for production deployments.** The `detail` field can expose internal error messages to clients. Use the `suppressDetail` option to omit it — either always, or based on custom logic.
+
+When you use Nest's built-in exceptions (e.g. `NotFoundException`, `BadRequestException`) or throw a plain `HttpException` without a custom `ProblemDetailsException`, the filter maps the exception's built-in message directly into `detail`. This means stack traces, database error strings, or other sensitive messages can leak to the client without any extra effort on your part.
+
+For example, throwing `new InternalServerErrorException('Database connection timeout')` will produce:
+
+```json
+{
+  "type": "internal-server-error",
+  "title": "Internal Server Error",
+  "status": 500,
+  "detail": "Database connection timeout"
+}
+```
+
+The `suppressDetail` option accepts either a boolean or a callback:
+
+```ts
+import { HttpExceptionFilter, SuppressDetail } from 'nest-problem-details-filter';
+
+// Always suppress detail on every response:
+app.useGlobalFilters(
+  new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, true),
+);
+
+// Or suppress selectively with a callback:
+app.useGlobalFilters(
+  new HttpExceptionFilter(
+    app.get(HttpAdapterHost),
+    '',
+    undefined,
+    ({ status }) => status >= 500,
+  ),
+);
+```
+
+With the callback above, `detail` is stripped from all 5xx responses while remaining visible on 4xx responses (where it is typically safe and useful, e.g. validation messages). See [`docs/usage.md`](./docs/usage.md#suppressing-detail-in-production) for the full API including the `SUPPRESS_DETAIL_KEY` DI token for module usage.
 
 ### As a module
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,6 +2,7 @@
 
 - [Usage Documentation](#usage-documentation)
   - [As a global filter](#as-a-global-filter)
+    - [Suppressing `detail` in production](#suppressing-detail-in-production)
   - [As a module](#as-a-module)
   - [Throwing exceptions](#throwing-exceptions)
     - [Recommended: `ProblemDetailsException`](#recommended-problemdetailsexception)
@@ -56,6 +57,88 @@ Will return:
   "title": "Dragon not found",
   "status": 404,
   "detail": "Could not find any dragon with ID: 99"
+}
+```
+
+### Suppressing `detail` in production
+
+> **Recommended for production deployments.** The `detail` field can expose internal error messages to clients. Use the `suppressDetail` option to omit it — either always, or based on custom logic.
+
+Pass `true` as the fourth constructor argument to suppress `detail` on every response:
+
+```ts
+import { HttpExceptionFilter } from 'nest-problem-details-filter';
+
+app.useGlobalFilters(
+  new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, true),
+);
+```
+
+Or pass a callback for conditional suppression. When the callback returns `true`, `detail` is omitted:
+
+```ts
+import { HttpExceptionFilter, SuppressDetail } from 'nest-problem-details-filter';
+
+const suppress: SuppressDetail = ({ status }) => status >= 500;
+
+app.useGlobalFilters(
+  new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, suppress),
+);
+```
+
+The callback receives a `SuppressDetailContext` with three fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `number` | HTTP status code of the response |
+| `type` | `string` | Resolved problem type URI |
+| `exception` | `HttpException` | The original caught exception |
+
+This allows fine-grained control:
+
+```ts
+// Hide detail for all 5xx errors
+({ status }) => status >= 500
+
+// Hide detail only for a specific problem type
+({ type }) => type === 'about:blank'
+
+// Keep detail visible for known safe exceptions, hide for everything else 5xx
+({ status, exception }) =>
+  status >= 500 && !(exception instanceof MyKnownSafeException)
+```
+
+When using the module, override the `SUPPRESS_DETAIL_KEY` provider. Use `true` to always suppress, or a callback for conditional logic:
+
+```ts
+import {
+  NestProblemDetailsModule,
+  HTTP_EXCEPTION_FILTER_KEY,
+  SUPPRESS_DETAIL_KEY,
+} from 'nest-problem-details-filter';
+
+@Module({
+  imports: [NestProblemDetailsModule],
+  providers: [
+    {
+      provide: APP_FILTER,
+      useExisting: HTTP_EXCEPTION_FILTER_KEY,
+    },
+    // Always suppress:
+    { provide: SUPPRESS_DETAIL_KEY, useValue: true },
+    // Or conditionally:
+    // { provide: SUPPRESS_DETAIL_KEY, useValue: ({ status }) => status >= 500 },
+  ],
+})
+```
+
+When `detail` is suppressed, the response omits the field entirely:
+
+```json
+{
+  "type": "internal-server-error",
+  "title": "Something went wrong",
+  "status": 500
 }
 ```
 

--- a/src/filter/constants.ts
+++ b/src/filter/constants.ts
@@ -48,6 +48,7 @@ export const DEFAULT_HTTP_ERRORS: IDefaultHTTPErrors = {
 export const BASE_PROBLEMS_URI_KEY = 'BASE_PROBLEMS_URI';
 export const HTTP_ERRORS_MAP_KEY = 'HTTP_ERRORS_MAP';
 export const HTTP_EXCEPTION_FILTER_KEY = 'HTTP_EXCEPTION_FILTER';
+export const SUPPRESS_DETAIL_KEY = 'SUPPRESS_DETAIL';
 
 export const PROBLEM_CONTENT_TYPE = 'application/problem+json';
 

--- a/src/filter/http-exception.filter.spec.ts
+++ b/src/filter/http-exception.filter.spec.ts
@@ -12,6 +12,7 @@ import {
   HTTP_ERRORS_MAP_KEY,
   BASE_PROBLEMS_URI_KEY,
   PROBLEM_CONTENT_TYPE,
+  SUPPRESS_DETAIL_KEY,
 } from './constants';
 import { NestProblemDetailsModule } from '../nest-problem-details.module';
 import { HttpAdapterHost } from '@nestjs/core';
@@ -294,6 +295,10 @@ describe('HttpExceptionFilter', () => {
             useValue: 'http://fcmam5.me/problems',
           },
           {
+            provide: SUPPRESS_DETAIL_KEY,
+            useValue: undefined,
+          },
+          {
             provide: HTTP_EXCEPTION_FILTER_KEY,
             useClass: HttpExceptionFilter,
           },
@@ -567,6 +572,121 @@ describe('HttpExceptionFilter', () => {
           ],
         } as unknown as IProblemDetail);
       });
+    });
+  });
+
+  describe('suppressDetail option', () => {
+    it('omits detail when suppressDetail returns true', () => {
+      const suppressFilter = new HttpExceptionFilter(
+        mockHttpAdapterHost as HttpAdapterHost,
+        '',
+        undefined,
+        ({ status }: { status: number }) => status >= 500,
+      );
+
+      suppressFilter.catch(
+        new HttpException(
+          { message: 'Oops', error: 'DB timeout', statusCode: 500 },
+          500,
+        ),
+        mockArgumentsHost,
+      );
+
+      expect(mockHttpAdapterHost.httpAdapter.reply).toHaveBeenCalledWith(
+        mockGetResponse(),
+        expect.objectContaining({ status: 500, detail: undefined }),
+        500,
+      );
+    });
+
+    it('keeps detail when suppressDetail returns false', () => {
+      const suppressFilter = new HttpExceptionFilter(
+        mockHttpAdapterHost as HttpAdapterHost,
+        '',
+        undefined,
+        ({ status }: { status: number }) => status >= 500,
+      );
+
+      suppressFilter.catch(
+        new HttpException(
+          { message: 'Not Found', error: 'Dragon missing', statusCode: 404 },
+          404,
+        ),
+        mockArgumentsHost,
+      );
+
+      expect(mockHttpAdapterHost.httpAdapter.reply).toHaveBeenCalledWith(
+        mockGetResponse(),
+        expect.objectContaining({ status: 404, detail: 'Dragon missing' }),
+        404,
+      );
+    });
+
+    it('keeps detail when suppressDetail is not configured', () => {
+      const bareFilter = new HttpExceptionFilter(
+        mockHttpAdapterHost as HttpAdapterHost,
+      );
+
+      bareFilter.catch(
+        new HttpException(
+          { message: 'Oops', error: 'DB timeout', statusCode: 500 },
+          500,
+        ),
+        mockArgumentsHost,
+      );
+
+      expect(mockHttpAdapterHost.httpAdapter.reply).toHaveBeenCalledWith(
+        mockGetResponse(),
+        expect.objectContaining({ status: 500, detail: 'DB timeout' }),
+        500,
+      );
+    });
+
+    it('omits detail on all responses when suppressDetail is true', () => {
+      const suppressFilter = new HttpExceptionFilter(
+        mockHttpAdapterHost as HttpAdapterHost,
+        '',
+        undefined,
+        true,
+      );
+
+      suppressFilter.catch(
+        new HttpException(
+          { message: 'Not Found', error: 'Dragon missing', statusCode: 404 },
+          404,
+        ),
+        mockArgumentsHost,
+      );
+
+      expect(mockHttpAdapterHost.httpAdapter.reply).toHaveBeenCalledWith(
+        mockGetResponse(),
+        expect.objectContaining({ status: 404, detail: undefined }),
+        404,
+      );
+    });
+
+    it('passes status, type, and exception to the callback', () => {
+      const suppressFn = jest.fn().mockReturnValue(false);
+      const suppressFilter = new HttpExceptionFilter(
+        mockHttpAdapterHost as HttpAdapterHost,
+        '',
+        undefined,
+        suppressFn,
+      );
+      const exception = new HttpException(
+        { message: 'Gone', error: 'Resource deleted', statusCode: 410 },
+        410,
+      );
+
+      suppressFilter.catch(exception, mockArgumentsHost);
+
+      expect(suppressFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 410,
+          type: 'gone',
+          exception,
+        }),
+      );
     });
   });
 

--- a/src/filter/http-exception.filter.spec.ts
+++ b/src/filter/http-exception.filter.spec.ts
@@ -665,6 +665,33 @@ describe('HttpExceptionFilter', () => {
       );
     });
 
+    it('preserves detail when the callback throws', () => {
+      const suppressFilter = new HttpExceptionFilter(
+        mockHttpAdapterHost as HttpAdapterHost,
+        '',
+        undefined,
+        () => {
+          throw new Error('boom');
+        },
+      );
+
+      expect(() =>
+        suppressFilter.catch(
+          new HttpException(
+            { message: 'Oops', error: 'DB timeout', statusCode: 500 },
+            500,
+          ),
+          mockArgumentsHost,
+        ),
+      ).not.toThrow();
+
+      expect(mockHttpAdapterHost.httpAdapter.reply).toHaveBeenCalledWith(
+        mockGetResponse(),
+        expect.objectContaining({ status: 500, detail: 'DB timeout' }),
+        500,
+      );
+    });
+
     it('passes status, type, and exception to the callback', () => {
       const suppressFn = jest.fn().mockReturnValue(false);
       const suppressFilter = new HttpExceptionFilter(

--- a/src/filter/http-exception.filter.ts
+++ b/src/filter/http-exception.filter.ts
@@ -11,8 +11,9 @@ import {
   DEFAULT_HTTP_ERRORS,
   HTTP_ERRORS_MAP_KEY,
   PROBLEM_CONTENT_TYPE,
+  SUPPRESS_DETAIL_KEY,
 } from './constants';
-import { IExceptionResponse } from './interfaces';
+import { IExceptionResponse, SuppressDetail } from './interfaces';
 import { formatRetryAfter } from '../exception/retry-after';
 import { isErrorObject } from './type-guards';
 import {
@@ -30,6 +31,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
     private baseUri = '',
     @Inject(HTTP_ERRORS_MAP_KEY)
     private defaultHttpErrors = DEFAULT_HTTP_ERRORS,
+    @Inject(SUPPRESS_DETAIL_KEY)
+    private suppressDetail: SuppressDetail | undefined = undefined,
   ) {}
 
   catch(exception: HttpException, host: ArgumentsHost): void {
@@ -79,12 +82,21 @@ export class HttpExceptionFilter implements ExceptionFilter {
       }
     }
 
+    const resolvedType = this.resolveType(type, status);
+
+    const shouldSuppress =
+      detail !== undefined &&
+      (this.suppressDetail === true ||
+        (typeof this.suppressDetail === 'function' &&
+          this.suppressDetail({ status, type: resolvedType, exception })));
+    const suppressedDetail = shouldSuppress ? undefined : detail;
+
     const responseBody: Record<string, unknown> = {
       ...objectExtras,
-      type: this.resolveType(type, status),
+      type: resolvedType,
       title: resolveProblemTitle(title, status),
       status,
-      detail,
+      detail: suppressedDetail,
     };
 
     if (errors !== undefined) {

--- a/src/filter/http-exception.filter.ts
+++ b/src/filter/http-exception.filter.ts
@@ -13,7 +13,11 @@ import {
   PROBLEM_CONTENT_TYPE,
   SUPPRESS_DETAIL_KEY,
 } from './constants';
-import { IExceptionResponse, SuppressDetail } from './interfaces';
+import {
+  IExceptionResponse,
+  SuppressDetail,
+  SuppressDetailContext,
+} from './interfaces';
 import { formatRetryAfter } from '../exception/retry-after';
 import { isErrorObject } from './type-guards';
 import {
@@ -24,6 +28,8 @@ import {
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly suppressDetailFn: (ctx: SuppressDetailContext) => boolean;
+
   constructor(
     @Inject(HttpAdapterHost)
     private readonly httpAdapterHost: HttpAdapterHost,
@@ -32,8 +38,15 @@ export class HttpExceptionFilter implements ExceptionFilter {
     @Inject(HTTP_ERRORS_MAP_KEY)
     private defaultHttpErrors = DEFAULT_HTTP_ERRORS,
     @Inject(SUPPRESS_DETAIL_KEY)
-    private suppressDetail: SuppressDetail | undefined = undefined,
-  ) {}
+    suppressDetail: SuppressDetail | undefined = undefined,
+  ) {
+    // Normalize boolean / undefined into a constant predicate so the request
+    // path only ever invokes a function.
+    this.suppressDetailFn =
+      typeof suppressDetail === 'function'
+        ? suppressDetail
+        : () => suppressDetail === true;
+  }
 
   catch(exception: HttpException, host: ArgumentsHost): void {
     const httpAdapter = this.httpAdapterHost.httpAdapter;
@@ -84,12 +97,13 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
     const resolvedType = this.resolveType(type, status);
 
-    const shouldSuppress =
-      detail !== undefined &&
-      (this.suppressDetail === true ||
-        (typeof this.suppressDetail === 'function' &&
-          this.suppressDetail({ status, type: resolvedType, exception })));
-    const suppressedDetail = shouldSuppress ? undefined : detail;
+    const suppressedDetail = this.shouldSuppressDetail(detail, {
+      status,
+      type: resolvedType,
+      exception,
+    })
+      ? undefined
+      : detail;
 
     const responseBody: Record<string, unknown> = {
       ...objectExtras,
@@ -125,6 +139,23 @@ export class HttpExceptionFilter implements ExceptionFilter {
       'Retry-After',
       formatted,
     );
+  }
+
+  /**
+   * Decide whether to omit the `detail` field. A throwing user-supplied
+   * callback must not crash the exception filter, so any error is swallowed
+   * and treated as "do not suppress".
+   */
+  private shouldSuppressDetail(
+    detail: string | undefined,
+    context: SuppressDetailContext,
+  ): boolean {
+    if (detail === undefined) return false;
+    try {
+      return this.suppressDetailFn(context);
+    } catch {
+      return false;
+    }
   }
 
   private resolveType(type: string | undefined, status: number): string {

--- a/src/filter/interfaces.ts
+++ b/src/filter/interfaces.ts
@@ -1,3 +1,5 @@
+import { HttpException as NestHttpException } from '@nestjs/common';
+
 /**
  * As specified in RFC 9457 §3 (formerly RFC 7807 §3.1).
  * https://datatracker.ietf.org/doc/html/rfc9457#section-3
@@ -21,6 +23,33 @@ export interface IErrorDetail {
     [key: string]: unknown;
   };
 }
+
+/**
+ * Context passed to the `suppressDetail` callback, describing the current
+ * Problem Details response before it is sent to the client.
+ */
+export interface SuppressDetailContext {
+  status: number;
+  type: string;
+  exception: NestHttpException;
+}
+
+/**
+ * Controls whether the `detail` field is omitted from the Problem Details
+ * response.
+ *
+ * - Pass `true` to suppress `detail` on every response.
+ * - Pass a callback to suppress conditionally; return `true` to omit.
+ *
+ * @example
+ * // Always suppress
+ * suppressDetail: true
+ *
+ * @example
+ * // Suppress only for 5xx errors
+ * suppressDetail: ({ status }) => status >= 500
+ */
+export type SuppressDetail = true | ((ctx: SuppressDetailContext) => boolean);
 
 /**
  * Shape of the payload returned by `HttpException.getResponse()` when not a

--- a/src/filter/interfaces.ts
+++ b/src/filter/interfaces.ts
@@ -39,6 +39,7 @@ export interface SuppressDetailContext {
  * response.
  *
  * - Pass `true` to suppress `detail` on every response.
+ * - Pass `false` (or omit) to never suppress.
  * - Pass a callback to suppress conditionally; return `true` to omit.
  *
  * @example
@@ -49,7 +50,9 @@ export interface SuppressDetailContext {
  * // Suppress only for 5xx errors
  * suppressDetail: ({ status }) => status >= 500
  */
-export type SuppressDetail = true | ((ctx: SuppressDetailContext) => boolean);
+export type SuppressDetail =
+  | boolean
+  | ((ctx: SuppressDetailContext) => boolean);
 
 /**
  * Shape of the payload returned by `HttpException.getResponse()` when not a

--- a/src/filter/providers.ts
+++ b/src/filter/providers.ts
@@ -4,6 +4,7 @@ import {
   HTTP_ERRORS_MAP_KEY,
   BASE_PROBLEMS_URI_KEY,
   HTTP_EXCEPTION_FILTER_KEY,
+  SUPPRESS_DETAIL_KEY,
 } from './constants';
 import { HttpExceptionFilter } from './http-exception.filter';
 
@@ -15,6 +16,11 @@ export const BASE_PROBLEMS_URI: Provider = {
 export const HTTP_ERRORS_MAP: Provider = {
   provide: HTTP_ERRORS_MAP_KEY,
   useValue: DEFAULT_HTTP_ERRORS,
+};
+
+export const SUPPRESS_DETAIL: Provider = {
+  provide: SUPPRESS_DETAIL_KEY,
+  useValue: undefined,
 };
 
 export const HTTP_EXCEPTION_FILTER: Provider = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,15 @@ export {
   HTTP_EXCEPTION_FILTER_KEY,
   PROBLEM_CONTENT_TYPE,
   DEFAULT_PROBLEM_TYPE,
+  SUPPRESS_DETAIL_KEY,
 } from './filter/constants';
 
 export {
   IProblemDetail,
   IErrorDetail,
   IExceptionResponse,
+  SuppressDetailContext,
+  SuppressDetail,
 } from './filter/interfaces';
 
 export {

--- a/src/nest-problem-details.module.ts
+++ b/src/nest-problem-details.module.ts
@@ -3,9 +3,15 @@ import {
   BASE_PROBLEMS_URI,
   HTTP_ERRORS_MAP,
   HTTP_EXCEPTION_FILTER,
+  SUPPRESS_DETAIL,
 } from './filter/providers';
 
-const providers = [BASE_PROBLEMS_URI, HTTP_ERRORS_MAP, HTTP_EXCEPTION_FILTER];
+const providers = [
+  BASE_PROBLEMS_URI,
+  HTTP_ERRORS_MAP,
+  SUPPRESS_DETAIL,
+  HTTP_EXCEPTION_FILTER,
+];
 
 @Module({
   providers,

--- a/tests/http-exception.generic.spec.ts
+++ b/tests/http-exception.generic.spec.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { HttpAdapterHost, NestFactory } from '@nestjs/core';
+import request from 'supertest';
 import { HttpExceptionFilter } from '../src';
 import { TestAppModule, TestAppModuleWithModule } from './test-app.module';
 import { runIntegrationTests } from './integration-tests.suite';
@@ -29,4 +30,49 @@ describe('Default (Generic) Adapter', () => {
     },
     getServer,
   );
+
+  describe('suppressDetail option', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      app = await NestFactory.create(TestAppModule);
+      app.useGlobalFilters(
+        new HttpExceptionFilter(
+          app.get(HttpAdapterHost),
+          '',
+          undefined,
+          ({ status }: { status: number }) => status >= 500,
+        ),
+      );
+      await app.init();
+    });
+
+    afterAll(() => app.close());
+
+    it('omits detail for 5xx responses', async () => {
+      const response = await request(getServer(app))
+        .get('/api/test/server-error')
+        .expect(500);
+
+      expect(response.body).toEqual({
+        type: 'internal-server-error',
+        title: 'Something went wrong',
+        status: 500,
+      });
+      expect(response.body).not.toHaveProperty('detail');
+    });
+
+    it('keeps detail for 4xx responses', async () => {
+      const response = await request(getServer(app))
+        .get('/api/test/custom-title-detail')
+        .expect(404);
+
+      expect(response.body).toEqual({
+        type: 'not-found',
+        title: 'Dragon not found',
+        status: 404,
+        detail: 'Could not find any dragon with ID: 99',
+      });
+    });
+  });
 });

--- a/tests/test-app.module.ts
+++ b/tests/test-app.module.ts
@@ -128,6 +128,18 @@ export class TestController {
     throw new HttpException(errorObj, parseInt(status, 10));
   }
 
+  @Get('server-error')
+  serverError(): void {
+    throw new HttpException(
+      {
+        message: 'Something went wrong',
+        error: 'Database connection timeout',
+        statusCode: 500,
+      },
+      500,
+    );
+  }
+
   @Get('business-error')
   @ApiProblemResponse({
     status: 403,


### PR DESCRIPTION

- Add `suppressDetail` constructor parameter (boolean or callback)
- Expose `SUPPRESS_DETAIL_KEY` DI token for module usage

resolves #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for suppressing the `detail` field in Problem Details responses, configurable as a boolean to disable globally or as a callback function for conditional suppression based on HTTP status and exception context.

* **Documentation**
  * Added comprehensive usage guidance for configuring detail suppression in production environments.

* **Tests**
  * Extended test coverage for detail suppression behavior across various scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fcmam5/nest-problem-details/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->