### PR TITLE
feat(module): add `.register()` and `.registerAsync()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Make NestJS return [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (fo
 - **Flexible validation error handling** - Three approaches from zero-config to full RFC 9457 JSON Pointer compliance (see [Validation errors](#validation-errors))
 - **Zero runtime dependencies** - Core filter has no runtime dependencies
 
-<!-- omit from toc --> 
+<!-- omit from toc -->
+
 ## Table of contents:
 
 - [NestHttpProblemDetails (RFC 9457 / RFC 7807)](#nesthttpproblemdetails-rfc-9457--rfc-7807)
@@ -85,7 +86,7 @@ Note that the `app.get(HttpAdapterHost)` argument is needed because the `HttpExc
 `HttpExceptionFilter` accepts a base URI for if you want to return absolute URIs for your problem types, e.g:
 
 ```ts
-  app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost), 'https://example.org'));
+app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost), 'https://example.org'));
 ```
 
 Will return:
@@ -122,49 +123,57 @@ The `suppressDetail` option accepts either a boolean or a callback:
 import { HttpExceptionFilter, SuppressDetail } from 'nest-problem-details-filter';
 
 // Always suppress detail on every response:
-app.useGlobalFilters(
-  new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, true),
-);
+app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, true));
 
 // Or suppress selectively with a callback:
-app.useGlobalFilters(
-  new HttpExceptionFilter(
-    app.get(HttpAdapterHost),
-    '',
-    undefined,
-    ({ status }) => status >= 500,
-  ),
-);
+app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, ({ status }) => status >= 500));
 ```
 
 With the callback above, `detail` is stripped from all 5xx responses while remaining visible on 4xx responses (where it is typically safe and useful, e.g. validation messages). See [`docs/usage.md`](./docs/usage.md#suppressing-detail-in-production) for the full API including the `SUPPRESS_DETAIL_KEY` DI token for module usage.
 
 ### As a module
 
-The library can be imported as a module, and then can use `HTTP_EXCEPTION_FILTER_KEY` to set `APP_FILTER`
+The library ships as a [dynamic module](https://docs.nestjs.com/fundamentals/dynamic-modules). Use `register()` (or `registerAsync()`) to configure it, and `HTTP_EXCEPTION_FILTER_KEY` to bind it to `APP_FILTER`:
 
 ```typescript
 import { APP_FILTER } from '@nestjs/core';
-import {
-  NestProblemDetailsModule,
-  HTTP_EXCEPTION_FILTER_KEY,
-} from 'nest-problem-details-filter';
+import { NestProblemDetailsModule, HTTP_EXCEPTION_FILTER_KEY } from 'nest-problem-details-filter';
 
 @Module({
-  imports: [NestProblemDetailsModule],
-  ...
+  imports: [
+    NestProblemDetailsModule.register({
+      baseUri: 'https://api.example.org/problems',
+      httpErrorsMap: { 418: 'teapot-error' },
+      suppressDetail: ({ status }) => status >= 500,
+    }),
+  ],
   providers: [
     {
       provide: APP_FILTER,
       useExisting: HTTP_EXCEPTION_FILTER_KEY,
     },
-    ...
   ],
 })
+export class AppModule {}
 ```
+
+For config-driven setups, `registerAsync()` resolves options from a factory:
+
+```typescript
+NestProblemDetailsModule.registerAsync({
+  imports: [ConfigModule],
+  inject: [ConfigService],
+  useFactory: (config: ConfigService) => ({
+    baseUri: config.get('PROBLEMS_BASE_URI'),
+  }),
+});
+```
+
+Importing `NestProblemDetailsModule` directly (without calling `register()`) still works and uses sensible defaults. The legacy pattern of overriding `BASE_PROBLEMS_URI_KEY`, `HTTP_ERRORS_MAP_KEY` and `SUPPRESS_DETAIL_KEY` providers manually is also still supported.
 
 See:
 
+- [NestJS Dynamic Modules](https://docs.nestjs.com/fundamentals/dynamic-modules)
 - [Custom providers: Alias providers (`useExisting`)](https://docs.nestjs.com/fundamentals/custom-providers#alias-providers-useexisting)
 - [Using `APP_FILTER` token](https://docs.nestjs.com/exception-filters#binding-filters)
 
@@ -358,6 +367,7 @@ Check the [`docs/`](./docs/) folder for usage examples and the [OpenAPI schema](
 The filter ships three flexible approaches for surfacing `class-validator` validation errors — all using the `errors` RFC 9457 extension member (not `detail`, per §3.1.4).
 
 > **Peer dependency:** the helpers below require `class-validator` (already a NestJS validation standard). Install it alongside the filter:
+>
 > ```bash
 > npm install class-validator
 > ```
@@ -372,10 +382,7 @@ Just register `ValidationPipe` + `HttpExceptionFilter`. The filter detects the `
   "title": "Bad Request",
   "status": 400,
   "detail": "Bad Request",
-  "errors": [
-    "username must be longer than or equal to 3 characters",
-    "email must be an email"
-  ]
+  "errors": ["username must be longer than or equal to 3 characters", "email must be an email"]
 }
 ```
 
@@ -387,9 +394,8 @@ Use `mapClassValidatorErrors()` in `exceptionFactory` for per-field grouping wit
 import { mapClassValidatorErrors } from 'nest-problem-details-filter/class-validator-mappers';
 
 new ValidationPipe({
-  exceptionFactory: (e) =>
-    new BadRequestException({ message: 'Validation failed', errors: mapClassValidatorErrors(e) }),
-})
+  exceptionFactory: (e) => new BadRequestException({ message: 'Validation failed', errors: mapClassValidatorErrors(e) }),
+});
 ```
 
 ```json
@@ -412,10 +418,10 @@ Use `toValidationProblemDetails()` for a one-liner that returns a `ProblemDetail
 import { toValidationProblemDetails } from 'nest-problem-details-filter/class-validator-mappers';
 
 // Field-map (default)
-new ValidationPipe({ exceptionFactory: (e) => toValidationProblemDetails(e) })
+new ValidationPipe({ exceptionFactory: (e) => toValidationProblemDetails(e) });
 
 // RFC 9457 JSON Pointer array
-new ValidationPipe({ exceptionFactory: (e) => toValidationProblemDetails(e, { usePointers: true }) })
+new ValidationPipe({ exceptionFactory: (e) => toValidationProblemDetails(e, { usePointers: true }) });
 ```
 
 Pointer format output:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,9 +69,7 @@ Pass `true` as the fourth constructor argument to suppress `detail` on every res
 ```ts
 import { HttpExceptionFilter } from 'nest-problem-details-filter';
 
-app.useGlobalFilters(
-  new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, true),
-);
+app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, true));
 ```
 
 Or pass a callback for conditional suppression. When the callback returns `true`, `detail` is omitted:
@@ -81,18 +79,16 @@ import { HttpExceptionFilter, SuppressDetail } from 'nest-problem-details-filter
 
 const suppress: SuppressDetail = ({ status }) => status >= 500;
 
-app.useGlobalFilters(
-  new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, suppress),
-);
+app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost), '', undefined, suppress));
 ```
 
 The callback receives a `SuppressDetailContext` with three fields:
 
-| Field | Type | Description |
-|---|---|---|
-| `status` | `number` | HTTP status code of the response |
-| `type` | `string` | Resolved problem type URI |
-| `exception` | `HttpException` | The original caught exception |
+| Field       | Type            | Description                      |
+| ----------- | --------------- | -------------------------------- |
+| `status`    | `number`        | HTTP status code of the response |
+| `type`      | `string`        | Resolved problem type URI        |
+| `exception` | `HttpException` | The original caught exception    |
 
 This allows fine-grained control:
 
@@ -144,30 +140,70 @@ When `detail` is suppressed, the response omits the field entirely:
 
 ## As a module
 
-The library can be imported as a module, and then you can use `HTTP_EXCEPTION_FILTER_KEY` to set `APP_FILTER`:
+The library ships as a [dynamic module](https://docs.nestjs.com/fundamentals/dynamic-modules). The recommended pattern is `NestProblemDetailsModule.register()`:
 
 ```typescript
 import { APP_FILTER } from '@nestjs/core';
-import {
-  NestProblemDetailsModule,
-  HTTP_EXCEPTION_FILTER_KEY,
-} from 'nest-problem-details-filter';
+import { NestProblemDetailsModule, HTTP_EXCEPTION_FILTER_KEY } from 'nest-problem-details-filter';
 
 @Module({
-  imports: [NestProblemDetailsModule],
-  // ...
+  imports: [
+    NestProblemDetailsModule.register({
+      baseUri: 'https://api.example.org/problems',
+      httpErrorsMap: { 418: 'teapot-error' },
+      suppressDetail: ({ status }) => status >= 500,
+    }),
+  ],
   providers: [
     {
       provide: APP_FILTER,
       useExisting: HTTP_EXCEPTION_FILTER_KEY,
     },
-    // ...
   ],
 })
+export class AppModule {}
 ```
+
+`register()` accepts:
+
+| Option           | Type                          | Default               | Description                                                                  |
+| ---------------- | ----------------------------- | --------------------- | ---------------------------------------------------------------------------- |
+| `baseUri`        | `string`                      | `''`                  | Base URI prepended to every problem `type`.                                  |
+| `httpErrorsMap`  | `Record<number, string>`      | `DEFAULT_HTTP_ERRORS` | Status-to-type slug overrides; merged on top of the defaults.                |
+| `suppressDetail` | `boolean \| (ctx) => boolean` | `undefined`           | See [Suppressing `detail` in production](#suppressing-detail-in-production). |
+
+### `registerAsync()`
+
+For options sourced from a `ConfigService` or another injectable:
+
+```typescript
+NestProblemDetailsModule.registerAsync({
+  imports: [ConfigModule],
+  inject: [ConfigService],
+  useFactory: (config: ConfigService) => ({
+    baseUri: config.get('PROBLEMS_BASE_URI'),
+    suppressDetail: config.get('NODE_ENV') === 'production',
+  }),
+});
+```
+
+### Static (zero-config) usage
+
+Importing `NestProblemDetailsModule` directly without calling `register()` still works and uses sensible defaults (empty `baseUri`, `DEFAULT_HTTP_ERRORS`, no `suppressDetail`):
+
+```typescript
+@Module({
+  imports: [NestProblemDetailsModule],
+  providers: [{ provide: APP_FILTER, useExisting: HTTP_EXCEPTION_FILTER_KEY }],
+})
+export class AppModule {}
+```
+
+The legacy pattern of overriding `BASE_PROBLEMS_URI_KEY`, `HTTP_ERRORS_MAP_KEY` and `SUPPRESS_DETAIL_KEY` providers manually is also still supported for advanced use cases.
 
 See:
 
+- [NestJS Dynamic Modules](https://docs.nestjs.com/fundamentals/dynamic-modules)
 - [Custom providers: Alias providers (`useExisting`)](https://docs.nestjs.com/fundamentals/custom-providers#alias-providers-useexisting)
 - [Using `APP_FILTER` token](https://docs.nestjs.com/exception-filters#binding-filters)
 
@@ -456,10 +492,7 @@ Content-Type: application/problem+json; charset=utf-8
 Code:
 
 ```js
-throw new NotFoundException(
-  'Dragon not found',
-  `Could not find any dragon with ID: ${id}`
-);
+throw new NotFoundException('Dragon not found', `Could not find any dragon with ID: ${id}`);
 ```
 
 Response:
@@ -483,6 +516,7 @@ Content-Type: application/problem+json; charset=utf-8
 The library supports three approaches for surfacing `class-validator` errors. Choose the one that fits your use case.
 
 > **Peer dependency:** these helpers require `class-validator` (already a NestJS validation standard). Install it alongside the filter:
+>
 > ```bash
 > npm install class-validator
 > ```
@@ -512,11 +546,7 @@ app.useGlobalFilters(new HttpExceptionFilter(app.get(HttpAdapterHost)));
   "title": "Bad Request",
   "status": 400,
   "detail": "Bad Request",
-  "errors": [
-    "username must be longer than or equal to 3 characters",
-    "email must be an email",
-    "address.street should not be empty"
-  ]
+  "errors": ["username must be longer than or equal to 3 characters", "email must be an email", "address.street should not be empty"]
 }
 ```
 
@@ -594,7 +624,7 @@ exceptionFactory: (e) =>
     status: 422,
     title: 'Unprocessable Entity',
     type: 'unprocessable-entity',
-  })
+  });
 ```
 
 ---
@@ -637,7 +667,7 @@ exceptionFactory: (validationErrors) =>
     title: 'Validation Failed',
     type: 'validation-error',
     errors: mapToPointerErrors(validationErrors),
-  })
+  });
 ```
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export { NestProblemDetailsModule } from './nest-problem-details.module';
+export {
+  NestProblemDetailsModule,
+  NestProblemDetailsModuleOptions,
+  NestProblemDetailsModuleAsyncOptions,
+} from './nest-problem-details.module';
 export { HttpExceptionFilter } from './filter/http-exception.filter';
 export {
   ProblemDetailsException,

--- a/src/nest-problem-details.module.spec.ts
+++ b/src/nest-problem-details.module.spec.ts
@@ -1,0 +1,161 @@
+import { Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import {
+  NestProblemDetailsModule,
+  BASE_PROBLEMS_URI_KEY,
+  HTTP_ERRORS_MAP_KEY,
+  SUPPRESS_DETAIL_KEY,
+  HTTP_EXCEPTION_FILTER_KEY,
+  DEFAULT_HTTP_ERRORS,
+  HttpExceptionFilter,
+} from '.';
+
+describe('NestProblemDetailsModule', () => {
+  describe('static module (default registration)', () => {
+    it('provides default values for all DI tokens', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [NestProblemDetailsModule],
+      }).compile();
+
+      expect(moduleRef.get(BASE_PROBLEMS_URI_KEY)).toBe('');
+      expect(moduleRef.get(HTTP_ERRORS_MAP_KEY)).toBe(DEFAULT_HTTP_ERRORS);
+      expect(moduleRef.get(SUPPRESS_DETAIL_KEY, { strict: false })).toBe(
+        undefined,
+      );
+      expect(moduleRef.get(HTTP_EXCEPTION_FILTER_KEY)).toBeInstanceOf(
+        HttpExceptionFilter,
+      );
+    });
+  });
+
+  describe('register()', () => {
+    it('applies provided baseUri, httpErrorsMap and suppressDetail', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          NestProblemDetailsModule.register({
+            baseUri: 'https://api.example.org/problems',
+            httpErrorsMap: { 418: 'teapot-error' },
+            suppressDetail: true,
+          }),
+        ],
+      }).compile();
+
+      expect(moduleRef.get(BASE_PROBLEMS_URI_KEY)).toBe(
+        'https://api.example.org/problems',
+      );
+      expect(moduleRef.get(HTTP_ERRORS_MAP_KEY)).toEqual({
+        ...DEFAULT_HTTP_ERRORS,
+        418: 'teapot-error',
+      });
+      expect(moduleRef.get(SUPPRESS_DETAIL_KEY)).toBe(true);
+      expect(moduleRef.get(HTTP_EXCEPTION_FILTER_KEY)).toBeInstanceOf(
+        HttpExceptionFilter,
+      );
+    });
+
+    it('falls back to defaults when called with no options', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [NestProblemDetailsModule.register()],
+      }).compile();
+
+      expect(moduleRef.get(BASE_PROBLEMS_URI_KEY)).toBe('');
+      expect(moduleRef.get(HTTP_ERRORS_MAP_KEY)).toEqual(DEFAULT_HTTP_ERRORS);
+      expect(moduleRef.get(SUPPRESS_DETAIL_KEY)).toBeUndefined();
+    });
+
+    it('merges httpErrorsMap on top of defaults without losing built-ins', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          NestProblemDetailsModule.register({
+            httpErrorsMap: { 404: 'custom-not-found' },
+          }),
+        ],
+      }).compile();
+
+      const map = moduleRef.get<Record<number, string>>(HTTP_ERRORS_MAP_KEY);
+      expect(map[404]).toBe('custom-not-found');
+      expect(map[500]).toBe(DEFAULT_HTTP_ERRORS[500]);
+    });
+  });
+
+  describe('registerAsync()', () => {
+    it('resolves options from a useFactory', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          NestProblemDetailsModule.registerAsync({
+            useFactory: () => ({
+              baseUri: 'https://async.example.org/problems',
+              suppressDetail: ({ status }) => status >= 500,
+            }),
+          }),
+        ],
+      }).compile();
+
+      expect(moduleRef.get(BASE_PROBLEMS_URI_KEY)).toBe(
+        'https://async.example.org/problems',
+      );
+      expect(typeof moduleRef.get(SUPPRESS_DETAIL_KEY)).toBe('function');
+    });
+
+    it('supports async factories returning a promise', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          NestProblemDetailsModule.registerAsync({
+            useFactory: async () => ({
+              baseUri: 'https://promised.example.org/problems',
+            }),
+          }),
+        ],
+      }).compile();
+
+      expect(moduleRef.get(BASE_PROBLEMS_URI_KEY)).toBe(
+        'https://promised.example.org/problems',
+      );
+    });
+
+    it('falls back to empty baseUri when factory omits it', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          NestProblemDetailsModule.registerAsync({
+            useFactory: () => ({}),
+          }),
+        ],
+      }).compile();
+
+      expect(moduleRef.get(BASE_PROBLEMS_URI_KEY)).toBe('');
+      expect(moduleRef.get(HTTP_ERRORS_MAP_KEY)).toEqual(DEFAULT_HTTP_ERRORS);
+      expect(moduleRef.get(SUPPRESS_DETAIL_KEY)).toBeUndefined();
+    });
+
+    it('injects dependencies into the factory', async () => {
+      const CONFIG_TOKEN = 'CONFIG_TOKEN';
+
+      @Module({
+        providers: [
+          {
+            provide: CONFIG_TOKEN,
+            useValue: { baseUri: 'https://injected.example.org' },
+          },
+        ],
+        exports: [CONFIG_TOKEN],
+      })
+      class ConfigModule {}
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          NestProblemDetailsModule.registerAsync({
+            imports: [ConfigModule],
+            inject: [CONFIG_TOKEN],
+            useFactory: (cfg: { baseUri: string }) => ({
+              baseUri: cfg.baseUri,
+            }),
+          }),
+        ],
+      }).compile();
+
+      expect(moduleRef.get(BASE_PROBLEMS_URI_KEY)).toBe(
+        'https://injected.example.org',
+      );
+    });
+  });
+});

--- a/src/nest-problem-details.module.ts
+++ b/src/nest-problem-details.module.ts
@@ -1,20 +1,164 @@
-import { Module } from '@nestjs/common';
+import {
+  DynamicModule,
+  ForwardReference,
+  InjectionToken,
+  Module,
+  OptionalFactoryDependency,
+  Provider,
+  Type,
+} from '@nestjs/common';
+import {
+  BASE_PROBLEMS_URI_KEY,
+  DEFAULT_HTTP_ERRORS,
+  HTTP_ERRORS_MAP_KEY,
+  SUPPRESS_DETAIL_KEY,
+} from './filter/constants';
 import {
   BASE_PROBLEMS_URI,
   HTTP_ERRORS_MAP,
   HTTP_EXCEPTION_FILTER,
   SUPPRESS_DETAIL,
 } from './filter/providers';
+import { SuppressDetail } from './filter/interfaces';
 
-const providers = [
+const staticProviders = [
   BASE_PROBLEMS_URI,
   HTTP_ERRORS_MAP,
   SUPPRESS_DETAIL,
   HTTP_EXCEPTION_FILTER,
 ];
 
+/**
+ * Options accepted by `NestProblemDetailsModule.register()`.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9457
+ */
+export interface NestProblemDetailsModuleOptions {
+  /**
+   * Base URI prepended to every `type` value in Problem Details responses.
+   * @example 'https://api.example.org/problems'
+   */
+  baseUri?: string;
+  /**
+   * Map of HTTP status codes to problem `type` slugs. Merged with
+   * `DEFAULT_HTTP_ERRORS`; entries here override the defaults.
+   */
+  httpErrorsMap?: Record<number, string>;
+  /**
+   * Controls whether the `detail` field is omitted from responses.
+   * @see SuppressDetail
+   */
+  suppressDetail?: SuppressDetail;
+}
+
+/**
+ * Async variant of `NestProblemDetailsModuleOptions` for `registerAsync()`.
+ */
+export interface NestProblemDetailsModuleAsyncOptions {
+  imports?: Array<
+    Type<unknown> | DynamicModule | Promise<DynamicModule> | ForwardReference
+  >;
+  inject?: Array<InjectionToken | OptionalFactoryDependency>;
+  useFactory: (
+    ...args: any[]
+  ) =>
+    | NestProblemDetailsModuleOptions
+    | Promise<NestProblemDetailsModuleOptions>;
+}
+
 @Module({
-  providers,
-  exports: providers,
+  providers: staticProviders,
+  exports: staticProviders,
 })
-export class NestProblemDetailsModule {}
+export class NestProblemDetailsModule {
+  /**
+   * Register the module with explicit options. Recommended over manually
+   * overriding the internal provider tokens.
+   *
+   * @example
+   * NestProblemDetailsModule.register({
+   *   baseUri: 'https://api.example.org/problems',
+   *   httpErrorsMap: { 418: 'teapot-error' },
+   *   suppressDetail: ({ status }) => status >= 500,
+   * })
+   */
+  static register(
+    options: NestProblemDetailsModuleOptions = {},
+  ): DynamicModule {
+    const providers: Provider[] = [
+      {
+        provide: BASE_PROBLEMS_URI_KEY,
+        useValue: options.baseUri ?? '',
+      },
+      {
+        provide: HTTP_ERRORS_MAP_KEY,
+        useValue: { ...DEFAULT_HTTP_ERRORS, ...(options.httpErrorsMap ?? {}) },
+      },
+      {
+        provide: SUPPRESS_DETAIL_KEY,
+        useValue: options.suppressDetail,
+      },
+      HTTP_EXCEPTION_FILTER,
+    ];
+
+    return {
+      module: NestProblemDetailsModule,
+      providers,
+      exports: providers,
+    };
+  }
+
+  /**
+   * Register the module asynchronously, resolving options from a factory.
+   * Useful when options come from a `ConfigService` or other injected source.
+   *
+   * @example
+   * NestProblemDetailsModule.registerAsync({
+   *   inject: [ConfigService],
+   *   useFactory: (config: ConfigService) => ({
+   *     baseUri: config.get('PROBLEMS_BASE_URI'),
+   *   }),
+   * })
+   */
+  static registerAsync(
+    options: NestProblemDetailsModuleAsyncOptions,
+  ): DynamicModule {
+    const OPTIONS_TOKEN = Symbol('NEST_PROBLEM_DETAILS_OPTIONS');
+
+    const providers: Provider[] = [
+      {
+        provide: OPTIONS_TOKEN,
+        useFactory: options.useFactory,
+        inject: options.inject ?? [],
+      },
+      {
+        provide: BASE_PROBLEMS_URI_KEY,
+        useFactory: (opts: NestProblemDetailsModuleOptions) =>
+          opts.baseUri ?? '',
+        inject: [OPTIONS_TOKEN],
+      },
+      {
+        provide: HTTP_ERRORS_MAP_KEY,
+        useFactory: (opts: NestProblemDetailsModuleOptions) => ({
+          ...DEFAULT_HTTP_ERRORS,
+          ...(opts.httpErrorsMap ?? {}),
+        }),
+        inject: [OPTIONS_TOKEN],
+      },
+      {
+        provide: SUPPRESS_DETAIL_KEY,
+        useFactory: (opts: NestProblemDetailsModuleOptions) =>
+          opts.suppressDetail,
+        inject: [OPTIONS_TOKEN],
+      },
+      HTTP_EXCEPTION_FILTER,
+    ];
+
+    return {
+      module: NestProblemDetailsModule,
+      imports: options.imports ?? [],
+      providers,
+      exports: providers,
+    };
+  }
+}

--- a/tests/http-exception.generic.spec.ts
+++ b/tests/http-exception.generic.spec.ts
@@ -2,7 +2,11 @@ import { INestApplication } from '@nestjs/common';
 import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import request from 'supertest';
 import { HttpExceptionFilter } from '../src';
-import { TestAppModule, TestAppModuleWithModule } from './test-app.module';
+import {
+  TestAppModule,
+  TestAppModuleWithModule,
+  TestAppModuleWithRegister,
+} from './test-app.module';
 import { runIntegrationTests } from './integration-tests.suite';
 
 function getServer(app: INestApplication): any {
@@ -30,6 +34,37 @@ describe('Default (Generic) Adapter', () => {
     },
     getServer,
   );
+
+  describe('NestProblemDetailsModule.register()', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      app = await NestFactory.create(TestAppModuleWithRegister);
+      await app.init();
+    });
+
+    afterAll(() => app.close());
+
+    it('uses the configured baseUri to build type URIs', async () => {
+      const response = await request(getServer(app))
+        .get('/api/test/default-not-found')
+        .expect(404);
+
+      expect(response.body.type).toBe(
+        'https://api.example.org/problems/not-found',
+      );
+    });
+
+    it('honors the configured httpErrorsMap override', async () => {
+      const response = await request(getServer(app))
+        .get('/api/test/generic-string/418')
+        .expect(418);
+
+      expect(response.body.type).toBe(
+        'https://api.example.org/problems/teapot-error',
+      );
+    });
+  });
 
   describe('suppressDetail option', () => {
     let app: INestApplication;

--- a/tests/test-app.module.ts
+++ b/tests/test-app.module.ts
@@ -315,3 +315,20 @@ export class TestAppModule {}
   ],
 })
 export class TestAppModuleWithModule {}
+
+@Module({
+  imports: [
+    NestProblemDetailsModule.register({
+      baseUri: 'https://api.example.org/problems',
+      httpErrorsMap: { 418: 'teapot-error' },
+    }),
+  ],
+  controllers: [TestController],
+  providers: [
+    {
+      provide: APP_FILTER,
+      useExisting: HTTP_EXCEPTION_FILTER_KEY,
+    },
+  ],
+})
+export class TestAppModuleWithRegister {}


### PR DESCRIPTION
Convert NestProblemDetailsModule into a dynamic module so consumers can configure baseUri, httpErrorsMap and suppressDetail through a typed options object instead of manually overriding internal provider tokens.

- register(options) — synchronous configuration, merges httpErrorsMap on top of DEFAULT_HTTP_ERRORS so built-in mappings are preserved.
- registerAsync({ imports, inject, useFactory }) — resolves options from an injectable factory (e.g. ConfigService), supports sync and async factories.
- Static NestProblemDetailsModule import keeps working with sensible defaults; legacy provider-override pattern remains supported.
- Export NestProblemDetailsModuleOptions and NestProblemDetailsModuleAsyncOptions.

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dynamic module configuration with `register()` and `registerAsync()` methods, enabling customization of base URI, HTTP error mappings, and production detail suppression settings.

* **Documentation**
  * Enhanced configuration documentation with updated examples demonstrating the new dynamic module registration APIs and their usage patterns.

* **Tests**
  * Added comprehensive test coverage for the new module configuration functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fcmam5/nest-problem-details/pull/39)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->