### PR TITLE
fix: validate RFC-9457 member types and coerce non-finite statuses 

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 # Reject installing any package version younger than 12 hours.
 # Defense against supply-chain attacks via newly-published malicious versions.
-# npm's min-release-age is expressed in DAYS (npm >= 11.5); fractions accepted.
+# npm's min-release-age is expressed in DAYS (npm >= 11.10.0); fractions accepted.
 # pnpm uses minimumReleaseAge in minutes (set in .pnpmrc if needed).
 # See: https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
 min-release-age=0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The filter now guards against a non-finite `status` (e.g. `NaN` from a failed `parseInt`) shipping an error as **HTTP 200** (#52). Both Nest adapters guard `res.status()` with `if (statusCode)`, and `NaN` is falsy, so the code is never applied and the error goes out as `200 OK` with `"status": null` — clients branching on `res.ok` read a server fault as success. This is upstream Nest behavior (stock Nest returns `200` + `{"statusCode":null}` for the same throw), but it breaks the §3.1.2 guarantee this filter exists to make, so non-finite statuses now fall back to `500`. Finite codes still pass through unchanged; `0` remains affected upstream.
+- Throwing with a non-finite status, such as `new HttpException('Oops', NaN)` from a failed `parseInt`, returned **HTTP 200** with an error body (#52). Nest's adapters only apply the status when it is truthy (`if (statusCode)`), and `NaN` is falsy, so the status was never set and the body carried `"status": null`. Clients checking `res.ok` read the failure as success. Non-finite statuses now become `500`. Finite codes are unchanged. Note this also happens in stock Nest without this filter, and `status: 0` is still affected by it.
 - `.npmrc`: corrected the config key from `minimum-release-age` to `min-release-age` (npm ≥ 11.10.0; value in days) and shortened the window from 3 days to 12 hours (`min-release-age=0.5`).
 
 ### Changed
 
-- (FWIW) `type`, `detail` and `instance` are now ignored when their runtime value is not a string, per RFC 9457 §3.1: `detail` and `instance` are omitted from the response, while `type` falls back to its usual default (the status-code slug, or `about:blank` under `strictRfcDefaults`). Mostly spec-lawyering — these are already typed as `string`, so the old behavior needed an `as any` or an untyped JS caller. Unlikely to affect you.
-- Under `strictRfcDefaults`, a wrong-typed `type` in the error-object form now maps `message` to `detail` (with `title` from the reason phrase), consistent with an exception that supplied no type at all. Previously any error object — even one with no usable `type` — forced `message` into `title`.
+- Non-string `type`, `detail` and `instance` values are no longer copied into the response. `HttpException` takes `Record<string, any>`, so nothing type-checks the nested `error` object: `error: { detail: null }` compiles fine and used to emit `"detail": null`. Wrong-typed `detail` and `instance` are now dropped, and `type` falls back to its usual default. RFC 9457 §3.1 requires ignoring members of the wrong type. Values passed through `ProblemDetailsException` were already rejected at compile time.
+- Under `strictRfcDefaults`, an error object whose `type` is not a string is now treated as having no type at all: `message` becomes `detail`, and `title` comes from the HTTP reason phrase. Previously the mere presence of an error object sent `message` to `title`, even when its `type` was unusable.
 
 ## [1.8.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `.npmrc` typo: `minimum-release-age` to `min-release-age` (npm >= 11.5 uses `min-release-age` in days); Use only 1 day for faster dependency updates.
+- The filter now guards against a non-finite `status` (e.g. `NaN` from a failed `parseInt`) shipping an error as **HTTP 200** (#52). Both Nest adapters guard `res.status()` with `if (statusCode)`, and `NaN` is falsy, so the code is never applied and the error goes out as `200 OK` with `"status": null` — clients branching on `res.ok` read a server fault as success. This is upstream Nest behavior (stock Nest returns `200` + `{"statusCode":null}` for the same throw), but it breaks the §3.1.2 guarantee this filter exists to make, so non-finite statuses now fall back to `500`. Finite codes still pass through unchanged; `0` remains affected upstream.
+- `.npmrc`: corrected the config key from `minimum-release-age` to `min-release-age` (npm ≥ 11.10.0; value in days) and shortened the window from 3 days to 12 hours (`min-release-age=0.5`).
+
+### Changed
+
+- (FWIW) `type`, `detail` and `instance` are now omitted when their runtime value is not a string, per RFC 9457 §3.1. Mostly spec-lawyering — these are already typed as `string`, so the old behavior needed an `as any` or an untyped JS caller. Unlikely to affect you.
 
 ## [1.8.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (FWIW) `type`, `detail` and `instance` are now omitted when their runtime value is not a string, per RFC 9457 §3.1. Mostly spec-lawyering — these are already typed as `string`, so the old behavior needed an `as any` or an untyped JS caller. Unlikely to affect you.
+- (FWIW) `type`, `detail` and `instance` are now ignored when their runtime value is not a string, per RFC 9457 §3.1: `detail` and `instance` are omitted from the response, while `type` falls back to its usual default (the status-code slug, or `about:blank` under `strictRfcDefaults`). Mostly spec-lawyering — these are already typed as `string`, so the old behavior needed an `as any` or an untyped JS caller. Unlikely to affect you.
+- Under `strictRfcDefaults`, a wrong-typed `type` in the error-object form now maps `message` to `detail` (with `title` from the reason phrase), consistent with an exception that supplied no type at all. Previously any error object — even one with no usable `type` — forced `message` into `title`.
 
 ## [1.8.0] - 2026-05-12
 

--- a/docs/rfc9457-compliance.md
+++ b/docs/rfc9457-compliance.md
@@ -89,12 +89,7 @@ Failing cases are marked `.skip` with a `TODO #<issue>` comment pointing to
 the tracking issue, so CI stays green while the gap remains visible and
 actionable:
 
-- [#52](https://github.com/Fcmam5/nest-problem-details/issues/52) — the
-  filter does not validate the runtime type of some standard members before
-  emitting them. Notably, an `HttpException` constructed with a `NaN` status
-  (e.g. from a failed `parseInt`) serializes to `"status": null` on the wire,
-  and `detail`/`instance`/`type`/`status` accept values of the wrong JSON
-  type (`null`, numbers, objects) instead of omitting them per §3.1.
+_None at this time._
 
 ## Running the suite
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-todo-tickets": "^1.4.0",
-    "fast-check": "4.9.0",
+    "fast-check": "^4.9.0",
     "globals": "^17.6.0",
     "jest": "^30.4.2",
     "prettier": "^3.8.3",

--- a/src/filter/http-exception.filter.spec.ts
+++ b/src/filter/http-exception.filter.spec.ts
@@ -822,6 +822,38 @@ describe('HttpExceptionFilter', () => {
         expect(body.type).toBe('about:blank');
       });
 
+      it('treats a wrong-typed type as no type at all for title/detail mapping', () => {
+        // A non-string `type` is discarded per §3.1, so this exception has no
+        // explicit type — `message` must map to detail, not title.
+        const f = makeStrictFilter();
+        const body = caughtBody(
+          f,
+          new HttpException(
+            {
+              message: 'Out of credit',
+              error: { type: 42 as unknown as string },
+            },
+            HttpStatus.FORBIDDEN,
+          ),
+        );
+        expect(body.type).toBe('about:blank');
+        expect(body.title).toBe('Forbidden');
+        expect(body.detail).toBe('Out of credit');
+      });
+
+      it('keeps an explicit detail over message when no type is supplied', () => {
+        const f = makeStrictFilter();
+        const body = caughtBody(
+          f,
+          new HttpException(
+            { message: 'Out of credit', error: { detail: 'Balance is 0.' } },
+            HttpStatus.FORBIDDEN,
+          ),
+        );
+        expect(body.title).toBe('Forbidden');
+        expect(body.detail).toBe('Balance is 0.');
+      });
+
       it('preserves explicit caller-supplied type even in strict mode', () => {
         const f = makeStrictFilter();
         const body = caughtBody(

--- a/src/filter/http-exception.filter.ts
+++ b/src/filter/http-exception.filter.ts
@@ -3,6 +3,7 @@ import {
   Catch,
   ArgumentsHost,
   HttpException,
+  HttpStatus,
   Inject,
 } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
@@ -21,7 +22,7 @@ import {
   SuppressDetailContext,
 } from './interfaces';
 import { formatRetryAfter } from '../exception/retry-after';
-import { isErrorObject } from './type-guards';
+import { asString, isErrorObject } from './type-guards';
 import {
   resolveProblemTitle,
   resolveProblemType,
@@ -74,13 +75,14 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
     const ctx = host.switchToHttp();
     const response = ctx.getResponse();
-    const status = exception.getStatus();
+    const status = this.normalizeStatus(exception.getStatus());
     const errorResponse = exception.getResponse() as
       string | IExceptionResponse;
 
     let title: string | undefined;
     let detail: string | undefined;
     let type: string | undefined;
+    let instance: string | undefined;
     let objectExtras: Record<string, unknown> | undefined;
     let errors: unknown;
 
@@ -102,6 +104,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
         title = undefined; // resolves to HTTP status reason phrase
         errors = message;
       } else if (typeof message === 'string') {
+        // The `typeof` above also keeps a wrong-typed `title` out of the
+        // response (§3.1) — it falls back to the reason phrase instead.
         // strictRfcDefaults + no explicit caller-supplied type:
         //   message is occurrence-specific → detail; title resolves from the
         //   HTTP reason phrase (left undefined here). This applies whether or
@@ -124,9 +128,17 @@ export class HttpExceptionFilter implements ExceptionFilter {
           detail = errorResponse.error;
         }
       } else if (isErrorObject(errorResponse.error)) {
-        const { type: _type, detail: _detail, ...rest } = errorResponse.error;
-        type = _type;
-        detail = _detail;
+        // `instance` is pulled out of the extras spread so it gets the same
+        // §3.1 type check as `type` and `detail`. See `asString`.
+        const {
+          type: _type,
+          detail: _detail,
+          instance: _instance,
+          ...rest
+        } = errorResponse.error;
+        type = asString(_type);
+        detail = asString(_detail);
+        instance = asString(_instance);
         objectExtras = rest;
       }
 
@@ -154,6 +166,10 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
     if (!shouldSuppressDetailInResponse && detail !== undefined) {
       responseBody['detail'] = detail;
+    }
+
+    if (instance !== undefined) {
+      responseBody['instance'] = instance;
     }
 
     if (errors !== undefined) {
@@ -199,6 +215,20 @@ export class HttpExceptionFilter implements ExceptionFilter {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Coerce `status` to something JSON can represent as a number (§3.1.2).
+   *
+   * `NaN`/`±Infinity` are `typeof 'number'` but `JSON.stringify` emits them as
+   * `null`, and `NaN` is falsy so Nest's adapters skip `res.status()` and the
+   * error ships as HTTP 200. Such a status is a server-side miscalculation
+   * (e.g. a failed `parseInt`), hence 500. Finite values pass through.
+   */
+  private normalizeStatus(status: unknown): number {
+    return typeof status === 'number' && Number.isFinite(status)
+      ? status
+      : HttpStatus.INTERNAL_SERVER_ERROR;
   }
 
   private resolveType(type: string | undefined, status: number): string {

--- a/src/filter/http-exception.filter.ts
+++ b/src/filter/http-exception.filter.ts
@@ -97,6 +97,23 @@ export class HttpExceptionFilter implements ExceptionFilter {
     } else {
       const message = errorResponse.message;
 
+      // Extracted before `message` is mapped: whether a *valid* `type` was
+      // supplied is what decides the strictRfcDefaults title/detail mapping
+      // below. `instance` is pulled out of the extras spread so it gets the
+      // same §3.1 type check as `type` and `detail`. See `asString`.
+      if (isErrorObject(errorResponse.error)) {
+        const {
+          type: _type,
+          detail: _detail,
+          instance: _instance,
+          ...rest
+        } = errorResponse.error;
+        type = asString(_type);
+        detail = asString(_detail);
+        instance = asString(_instance);
+        objectExtras = rest;
+      }
+
       if (Array.isArray(message) && message.length > 0) {
         // Approach 1: Nest's default ValidationPipe emits a flat string[].
         // Per RFC 9457 §3.1.4 consumers SHOULD NOT parse `detail` for
@@ -110,36 +127,25 @@ export class HttpExceptionFilter implements ExceptionFilter {
         //   message is occurrence-specific → detail; title resolves from the
         //   HTTP reason phrase (left undefined here). This applies whether or
         //   not a string `error` field is present, and to any exception that
-        //   lacks an explicit type via the error-object form.
+        //   lacks an explicit type via the error-object form — including one
+        //   whose `type` was discarded for being wrong-typed.
         // Legacy, or caller provided an explicit type via the error-object form:
         //   `message` is the best available title — keep legacy mapping.
-        if (this.strictRfcDefaults && !isErrorObject(errorResponse.error)) {
-          detail = message;
+        if (this.strictRfcDefaults && type === undefined) {
+          // An explicit `detail` from the error object is more specific than
+          // `message`, so it wins; `message` is occurrence-specific and must
+          // not become `title` in strict mode.
+          detail ??= message;
         } else {
           title = message;
         }
       }
 
-      if (typeof errorResponse.error === 'string') {
-        // strictRfcDefaults: title resolves from status; the NestJS `error`
-        // string is redundant — drop it (detail was already set above).
+      if (typeof errorResponse.error === 'string' && !this.strictRfcDefaults) {
         // Legacy: the `error` string (HTTP reason phrase) maps to detail.
-        if (!this.strictRfcDefaults) {
-          detail = errorResponse.error;
-        }
-      } else if (isErrorObject(errorResponse.error)) {
-        // `instance` is pulled out of the extras spread so it gets the same
-        // §3.1 type check as `type` and `detail`. See `asString`.
-        const {
-          type: _type,
-          detail: _detail,
-          instance: _instance,
-          ...rest
-        } = errorResponse.error;
-        type = asString(_type);
-        detail = asString(_detail);
-        instance = asString(_instance);
-        objectExtras = rest;
+        // strictRfcDefaults: title resolves from status and the NestJS `error`
+        // string is redundant — drop it (detail was already set above).
+        detail = errorResponse.error;
       }
 
       // Approaches 2 & 3: caller supplied a structured `errors` value

--- a/src/filter/type-guards.ts
+++ b/src/filter/type-guards.ts
@@ -12,13 +12,18 @@ export function isErrorObject(
 }
 
 /**
- * Narrow a value to a `string`, or `undefined` for any other type, so the
- * filter treats a wrong-typed member as absent — RFC 9457 §3.1 requires such a
- * member to be "ignored".
+ * Returns `value` when it is a string, otherwise `undefined`.
  *
- * Mostly spec-lawyering: these members are already typed as `string`, so only
- * untyped JS callers or an explicit `as any` reach this. Kept because it costs
- * one branch, not because it is a realistic hazard.
+ * Used on `type`, `detail` and `instance` so a wrong-typed value is treated as
+ * if the caller never set it, which is what RFC 9457 §3.1 asks for.
+ *
+ * Easy to hit by accident: `HttpException` takes `Record<string, any>`, so the
+ * nested `error` object is never type-checked. This compiles under `--strict`
+ * and used to put `"detail": null` on the wire:
+ *
+ *     new HttpException({ message: 'Nope', error: { detail: null } }, 400);
+ *
+ * `ProblemDetailsException` does type these members, so that path was safe.
  */
 export function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;

--- a/src/filter/type-guards.ts
+++ b/src/filter/type-guards.ts
@@ -10,3 +10,16 @@ export function isErrorObject(
 ): value is NonNullable<IErrorDetail['error']> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
+
+/**
+ * Narrow a value to a `string`, or `undefined` for any other type, so the
+ * filter treats a wrong-typed member as absent — RFC 9457 §3.1 requires such a
+ * member to be "ignored".
+ *
+ * Mostly spec-lawyering: these members are already typed as `string`, so only
+ * untyped JS callers or an explicit `as any` reach this. Kept because it costs
+ * one branch, not because it is a realistic hazard.
+ */
+export function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}

--- a/tests/rfc9457/detail.spec.ts
+++ b/tests/rfc9457/detail.spec.ts
@@ -92,9 +92,7 @@ describe('RFC 9457 §3.1.4 — detail', () => {
     expect(body).not.toHaveProperty('detail');
   });
 
-  // TODO #52: fails today — `detail: null` is emitted verbatim instead of
-  // being omitted. Skipped so CI stays green until that's fixed.
-  it.skip('MUST ignore a detail whose value type is not a string (§3.1)', () => {
+  it('MUST ignore a detail whose value type is not a string (§3.1)', () => {
     const f = makeFilter();
     const body = caughtBody(
       f,

--- a/tests/rfc9457/instance.spec.ts
+++ b/tests/rfc9457/instance.spec.ts
@@ -63,9 +63,7 @@ describe('RFC 9457 §3.1.5 — instance', () => {
     expect(body).not.toHaveProperty('instance');
   });
 
-  // TODO #52: fails today — `instance: null` is emitted verbatim instead of
-  // being omitted. Skipped so CI stays green until that's fixed.
-  it.skip('MUST ignore an instance whose value type is not a string (§3.1)', () => {
+  it('MUST ignore an instance whose value type is not a string (§3.1)', () => {
     const f = makeFilter();
     const body = caughtBody(
       f,

--- a/tests/rfc9457/member-types.spec.ts
+++ b/tests/rfc9457/member-types.spec.ts
@@ -63,19 +63,34 @@ describe('RFC 9457 §3.1 — member value types', () => {
     });
   });
 
-  it('MUST always emit type as a string, never a non-string', () => {
-    const f = makeFilter();
-    const body = caughtBody(
-      f,
-      new ProblemDetailsException({
-        status: HttpStatus.BAD_REQUEST,
-        title: 'Bad Request',
-        type: 42 as unknown as string,
-      }),
-    );
+  it.each(malformed)(
+    'MUST ignore a type that is %s, falling back to the default type',
+    (_label, value) => {
+      // The control: the same problem with no `type` at all. A wrong-typed
+      // `type` must be *ignored* (§3.1), i.e. produce exactly this — not a
+      // stringified version of the bad value.
+      const fallback = caughtBody(
+        makeFilter(),
+        new ProblemDetailsException({
+          status: HttpStatus.BAD_REQUEST,
+          title: 'Bad Request',
+        }),
+      ).type;
 
-    expect(typeof body.type).toBe('string');
-  });
+      const body = caughtBody(
+        makeFilter(),
+        new ProblemDetailsException({
+          status: HttpStatus.BAD_REQUEST,
+          title: 'Bad Request',
+          type: value as unknown as string,
+        }),
+      );
+
+      expect(typeof body.type).toBe('string');
+      expect(body.type).toBe(fallback);
+      expect(body.type).not.toBe(String(value));
+    },
+  );
 
   it('MUST always emit title as a string, never a non-string', () => {
     const f = makeFilter();
@@ -100,6 +115,9 @@ describe('RFC 9457 §3.1 — member value types', () => {
       }),
     );
 
+    // `status` cannot be omitted (it is also the HTTP reply code), so a
+    // wrong-typed value degrades to 500 rather than being coerced to 400.
     expect(typeof body.status).toBe('number');
+    expect(body.status).toBe(500);
   });
 });

--- a/tests/rfc9457/member-types.spec.ts
+++ b/tests/rfc9457/member-types.spec.ts
@@ -31,10 +31,7 @@ describe('RFC 9457 §3.1 — member value types', () => {
     ['an array', ['a', 'b']],
   ] as const;
 
-  // TODO #52: all cases below fail — wrongly-typed detail values are
-  // forwarded verbatim instead of being omitted. Skipped so CI stays green
-  // until that's fixed.
-  describe.skip.each(malformed)('when detail is %s', (_label, value) => {
+  describe.each(malformed)('when detail is %s', (_label, value) => {
     it('MUST be ignored (i.e., not emitted) per §3.1', () => {
       const f = makeFilter();
       const body = caughtBody(
@@ -50,10 +47,7 @@ describe('RFC 9457 §3.1 — member value types', () => {
     });
   });
 
-  // TODO #52: all cases below fail — wrongly-typed instance values are
-  // forwarded verbatim instead of being omitted. Skipped so CI stays green
-  // until that's fixed.
-  describe.skip.each(malformed)('when instance is %s', (_label, value) => {
+  describe.each(malformed)('when instance is %s', (_label, value) => {
     it('MUST be ignored (i.e., not emitted) per §3.1', () => {
       const f = makeFilter();
       const body = caughtBody(
@@ -69,9 +63,7 @@ describe('RFC 9457 §3.1 — member value types', () => {
     });
   });
 
-  // TODO #52: fails today — a numeric `type` is forwarded unchanged. Skipped
-  // so CI stays green until that's fixed.
-  it.skip('MUST always emit type as a string, never a non-string', () => {
+  it('MUST always emit type as a string, never a non-string', () => {
     const f = makeFilter();
     const body = caughtBody(
       f,
@@ -98,10 +90,7 @@ describe('RFC 9457 §3.1 — member value types', () => {
     expect(typeof body.title).toBe('string');
   });
 
-  // TODO #52: fails today — a stringified status ('400') is forwarded
-  // unchanged instead of being rejected/coerced. Skipped so CI stays green
-  // until that's fixed.
-  it.skip('MUST always emit status as a number, never a string', () => {
+  it('MUST always emit status as a number, never a string', () => {
     const f = makeFilter();
     const body = caughtBody(
       f,

--- a/tests/status-edge-cases.spec.ts
+++ b/tests/status-edge-cases.spec.ts
@@ -49,23 +49,36 @@ describe('HttpExceptionFilter — status edge cases', () => {
     expect(typeof roundTripped.status).toBe('number');
   });
 
-  // TODO #52: `JSON.stringify(NaN)` produces `null`, so the `status` member
-  // is no longer a number on the wire. This should be resolved by the
-  // runtime type validation work.
-  it.skip('does not serialize NaN as a JSON number', () => {
+  // Non-finite numbers pass a `typeof === 'number'` check but serialize as
+  // `null`, so they cannot be passed through. They degrade to 500 instead.
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['-Infinity', Number.NEGATIVE_INFINITY],
+    // Non-numeric statuses can only arrive from untyped callers.
+    ['a numeric string', '400' as unknown as number],
+    ['a non-numeric string', 'oops' as unknown as number],
+    ['null', null as unknown as number],
+    ['undefined', undefined as unknown as number],
+  ])('falls back to 500 when status is %s', (_label, status) => {
+    const f = makeFilter();
+
+    const { body, status: replied } = caughtResponse(
+      f,
+      new HttpException('Oops', status),
+    );
+
+    expect(body.status).toBe(500);
+    expect(replied).toBe(500);
+    expect(body.status).toBe(replied);
+  });
+
+  it('serializes a non-finite status as a JSON number, not null', () => {
     const f = makeFilter();
     const body = caughtBody(f, new HttpException('Oops', Number.NaN));
 
     const roundTripped = JSON.parse(JSON.stringify(body));
     expect(typeof roundTripped.status).toBe('number');
-  });
-
-  it('passes NaN through to both the body and the HTTP reply', () => {
-    const f = makeFilter();
-    const ex = new HttpException('Oops', Number.NaN);
-
-    const { body, status: replied } = caughtResponse(f, ex);
-
-    expect(Object.is(body.status, replied)).toBe(true);
+    expect(roundTripped.status).not.toBeNull();
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or non-finite HTTP statuses now consistently fall back to status 500.
  * Problem responses omit non-string `type`, `detail`, and `instance` values.
  * Valid `instance` values are preserved correctly.
  * Improved strict RFC 9457 handling for malformed error types and explicit details.

* **Documentation**
  * Updated RFC 9457 compliance documentation and the unreleased changelog.

* **Tests**
  * Expanded coverage for invalid member types, status values, and JSON serialization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->